### PR TITLE
Geolocate ip addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 .env
 deploy.env
 build
+
+# Maxmind db
+db

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ we also append the BigQuery date partition to the table name, eg
 
 # Installation
 
-To get started, just `npm install`.
+To get started, just `npm install`.  And since you'll need to download the
+[GeoLite2 City database](http://dev.maxmind.com/geoip/geoip2/geolite2/), also run
+`npm geolite`.
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ we also append the BigQuery date partition to the table name, eg
 
 # Installation
 
-To get started, just `npm install`.  And since you'll need to download the
-[GeoLite2 City database](http://dev.maxmind.com/geoip/geoip2/geolite2/), also run
-`npm geolite`.
+To get started, first run an `npm install`.  Then run `npm run geolite` to download
+the [GeoLite2 City database](http://dev.maxmind.com/geoip/geoip2/geolite2/).
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ various metric records are either recognized by an input source in `lib/inputs`,
 or ignored and logged as an error at the end of the lambda execution.
 
 The records are then parsed into BigQuery table formats, and inserted into their
-corresponding BigQuery tables in parallel.
+corresponding BigQuery tables in parallel.  This is called
+[streaming inserts](https://cloud.google.com/bigquery/streaming-data-into-bigquery),
+and in case the insert fails, it will be attempted 2 more times before the Lambda
+fails with an error.  And since each insert includes a unique `insertId`, we
+don't have any data consistency issues with re-running the inserts.
 
 Because the timestamp on the metric may lag behind the lambda execution time,
 we also append the BigQuery date partition to the table name, eg

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -1,11 +1,20 @@
 'use strict';
 const dotenv = require('dotenv');
 const lambda = require('node-lambda');
+const fs     = require('fs');
 
 // environment name
 let envName = process.argv[2];
 if (['development', 'staging', 'production'].indexOf(envName) < 0) {
   console.error('Usage: deploy.js [development|staging|production]');
+  process.exit(1);
+}
+
+// make sure maxmind is downloaded
+try {
+  fs.statSync(`${__dirname}/../db/GeoLite2-City.mmdb`);
+} catch (e) {
+  console.error('Geolite database not downloaded - run "npm run geolite".');
   process.exit(1);
 }
 

--- a/bin/getmaxmind.js
+++ b/bin/getmaxmind.js
@@ -11,11 +11,19 @@ const DB_FILE = `${DB_DIR}/GeoLite2-City.mmdb`;
 // check for existing file
 try {
   fs.mkdirSync(DB_DIR);
-} catch (e) {}
+} catch (e) {
+  if (e.code !== 'EEXIST') {
+    throw e;
+  }
+}
 try {
   fs.statSync(DB_FILE);
-  process.exit(0);
-} catch (e) {}
+  process.exit(0); // nothing to do
+} catch (e) {
+  if (e.code !== 'ENOENT') {
+    throw e;
+  }
+}
 
 // download file
 let file = fs.createWriteStream(GZ_FILE);

--- a/bin/getmaxmind.js
+++ b/bin/getmaxmind.js
@@ -1,0 +1,47 @@
+'use strict';
+const fs = require('fs');
+const http = require('http');
+const targz = require('targz');
+
+const URL = 'http://geolite.maxmind.com/download/geoip/database/GeoLite2-City.tar.gz';
+const DB_DIR = `${__dirname}/../db`;
+const GZ_FILE = `${DB_DIR}/GeoLite2-City.tar.gz`;
+const DB_FILE = `${DB_DIR}/GeoLite2-City.mmdb`;
+
+// check for existing file
+try {
+  fs.mkdirSync(DB_DIR);
+} catch (e) {}
+try {
+  fs.statSync(DB_FILE);
+  process.exit(0);
+} catch (e) {}
+
+// download file
+let file = fs.createWriteStream(GZ_FILE);
+http.get(URL, res => {
+  if (res.statusCode === 200) {
+    res.pipe(file);
+    res.on('error', err => console.error(err) && process.exit(1));
+    res.on('end', () => extract());
+  } else {
+    console.error(`Got ${res.statusCode} from ${URL}`);
+    process.exit(1);
+  }
+});
+
+// extract database file
+function extract() {
+  targz.decompress({src: GZ_FILE, dest: DB_DIR, tar: {
+    map: h => (h.name = h.name.split('/').pop()) && h,
+    ignore: name => !name.match('GeoLite2-City.mmdb')
+  }}, err => {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    } else {
+      fs.unlinkSync(GZ_FILE);
+      fs.statSync(DB_FILE);
+    }
+  });
+}

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -33,7 +33,10 @@ exports.dataset = (forceRefresh) => {
 /**
  * Streaming inserts (returns promise)
  */
-exports.insert = (table, rows, retries = 2) => {
+exports.insert = (table, rows, retries) => {
+  if (retries === undefined) {
+    retries = 2;
+  }
   if (rows.length === 0) {
     return Promise.resolve(0);
   }

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -33,7 +33,7 @@ exports.dataset = (forceRefresh) => {
 /**
  * Streaming inserts (returns promise)
  */
-exports.insert = (table, rows) => {
+exports.insert = (table, rows, retries = 2) => {
   if (rows.length === 0) {
     return Promise.resolve(0);
   }
@@ -56,8 +56,11 @@ exports.insert = (table, rows) => {
         throw new Error('You forgot to set BQ_PROJECT_ID');
       } else if (err.message.match(/Not Found/)) {
         throw new Error(`Could not find table: ${err.response.req.path}`)
+      } else if (retries > 0) {
+        return exports.insert(table, rows, retries - 1);
+      } else {
+        throw err;
       }
-      throw err;
     }
   );
 };

--- a/lib/inputs/dovetail-download.js
+++ b/lib/inputs/dovetail-download.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const timestamp = require('../timestamp');
+const lookip = require('../lookip');
 
 /**
  * Does this look like a dovetail download record?
@@ -22,21 +23,25 @@ exports.table = (record) => {
  * Convert to bigquery table format
  */
 exports.format = (record) => {
-  return {
-    insertId: record.requestUuid,
-    json: {
-      digest:         record.digest,
-      program:        record.program,
-      path:           record.path,
-      feeder_podcast: record.feederPodcast,
-      feeder_episode: record.feederEpisode,
-      remote_agent:   record.remoteAgent,
-      remote_ip:      record.remoteIp,
-      timestamp:      timestamp.toEpochSeconds(record.timestamp || 0),
-      request_uuid:   record.requestUuid,
-      ad_count:       record.adCount,
-      is_duplicate:   record.isDuplicate,
-      cause:          record.cause
-    }
-  };
+  return lookip.look(record.remoteIp).then(look => {
+    return {
+      insertId: record.requestUuid,
+      json: {
+        digest:         record.digest,
+        program:        record.program,
+        path:           record.path,
+        feeder_podcast: record.feederPodcast,
+        feeder_episode: record.feederEpisode,
+        remote_agent:   record.remoteAgent,
+        remote_ip:      record.remoteIp,
+        timestamp:      timestamp.toEpochSeconds(record.timestamp || 0),
+        request_uuid:   record.requestUuid,
+        ad_count:       record.adCount,
+        is_duplicate:   record.isDuplicate,
+        cause:          record.cause,
+        city_id:        look.city,
+        countryId:      look.country
+      }
+    };
+  });
 };

--- a/lib/inputs/dovetail-download.js
+++ b/lib/inputs/dovetail-download.js
@@ -40,7 +40,7 @@ exports.format = (record) => {
         is_duplicate:   record.isDuplicate,
         cause:          record.cause,
         city_id:        look.city,
-        countryId:      look.country
+        country_id:     look.country
       }
     };
   });

--- a/lib/inputs/dovetail-impression.js
+++ b/lib/inputs/dovetail-impression.js
@@ -2,6 +2,7 @@
 
 const uuid = require('uuid');
 const timestamp = require('../timestamp');
+const lookip = require('../lookip');
 
 /**
  * Does this look like a dovetail impression record?
@@ -26,24 +27,28 @@ exports.table = (record) => {
  * might serve up the same ad more than once. So just generate an insert id.
  */
 exports.format = (record) => {
-  return {
-    insertId: uuid.v4(),
-    json: {
-      digest:         record.digest,
-      program:        record.program,
-      path:           record.path,
-      feeder_podcast: record.feederPodcast,
-      feeder_episode: record.feederEpisode,
-      remote_agent:   record.remoteAgent,
-      remote_ip:      record.remoteIp,
-      timestamp:      timestamp.toEpochSeconds(record.timestamp || 0),
-      request_uuid:   record.requestUuid,
-      ad_id:          record.adId,
-      campaign_id:    record.campaignId,
-      creative_id:    record.creativeId,
-      flight_id:      record.flightId,
-      is_duplicate:   record.isDuplicate,
-      cause:          record.cause
-    }
-  };
+  return lookip.look(record.remoteIp).then(look => {
+    return {
+      insertId: uuid.v4(),
+      json: {
+        digest:         record.digest,
+        program:        record.program,
+        path:           record.path,
+        feeder_podcast: record.feederPodcast,
+        feeder_episode: record.feederEpisode,
+        remote_agent:   record.remoteAgent,
+        remote_ip:      record.remoteIp,
+        timestamp:      timestamp.toEpochSeconds(record.timestamp || 0),
+        request_uuid:   record.requestUuid,
+        ad_id:          record.adId,
+        campaign_id:    record.campaignId,
+        creative_id:    record.creativeId,
+        flight_id:      record.flightId,
+        is_duplicate:   record.isDuplicate,
+        cause:          record.cause,
+        city_id:        look.city,
+        countryId:      look.country
+      }
+    };
+  });
 };

--- a/lib/inputs/dovetail-impression.js
+++ b/lib/inputs/dovetail-impression.js
@@ -47,7 +47,7 @@ exports.format = (record) => {
         is_duplicate:   record.isDuplicate,
         cause:          record.cause,
         city_id:        look.city,
-        countryId:      look.country
+        country_id:     look.country
       }
     };
   });

--- a/lib/inputs/dovetail-impression.js
+++ b/lib/inputs/dovetail-impression.js
@@ -1,8 +1,21 @@
 'use strict';
 
-const uuid = require('uuid');
+const crypto = require('crypto');
 const timestamp = require('../timestamp');
 const lookip = require('../lookip');
+
+// unique insert id ... req uuid + ad info
+// TODO: this ASSUMES any ad is only found once per arrangement!!!
+function md5(record) {
+  let data = [
+    record.requestUuid,
+    record.adId,
+    record.campaignId,
+    record.creativeId,
+    record.flightId
+  ].join('-');
+  return crypto.createHash('md5').update(data).digest('hex');
+}
 
 /**
  * Does this look like a dovetail impression record?
@@ -29,7 +42,7 @@ exports.table = (record) => {
 exports.format = (record) => {
   return lookip.look(record.remoteIp).then(look => {
     return {
-      insertId: uuid.v4(),
+      insertId: md5(record),
       json: {
         digest:         record.digest,
         program:        record.program,

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -10,7 +10,7 @@ const TYPES = [dovetailDownload, dovetailImpression];
 module.exports = class Inputs {
 
   constructor(records) {
-    this._records = {};
+    this._tables = {};
     this._unknowns = [];
 
     // group records by type
@@ -19,10 +19,10 @@ module.exports = class Inputs {
         let inputType = TYPES.find(t => t.check(r));
         if (inputType) {
           let table = inputType.table(r);
-          if (this._records[table]) {
-            this._records[table].push(inputType.format(r));
+          if (this._tables[table]) {
+            this._tables[table].push(inputType.format(r));
           } else {
-            this._records[table] = [inputType.format(r)];
+            this._tables[table] = [inputType.format(r)];
           }
         } else {
           this._unknowns.push(r);
@@ -32,17 +32,21 @@ module.exports = class Inputs {
   }
 
   get tables() {
-    return Object.keys(this._records);
+    return Object.keys(this._tables);
   }
 
   get unrecognized() {
     return this._unknowns;
   }
 
-  get outputs() {
-    return Object.keys(this._records).map(tableName => {
-      return [tableName, this._records[tableName]];
-    });
+  formatRecordsForTable(tbl) {
+    return Promise.all(this._tables[tbl]);
+  }
+
+  formatRecords() {
+    return Promise.all(Object.keys(this._tables).map(t => {
+      return this.formatRecordsForTable(t).then(formatted => [t, formatted]);
+    }));
   }
 
 }

--- a/lib/lookip.js
+++ b/lib/lookip.js
@@ -1,0 +1,60 @@
+'use strict';
+const maxmind = require('maxmind');
+const dbfile = `${__dirname}/../db/GeoLite2-City.mmdb`;
+
+// maxmind singleton
+let _maxdb;
+function maxdb() {
+  if (_maxdb) {
+    return _maxdb;
+  } else {
+    return _maxdb = new Promise((resolve, reject) => {
+      maxmind.open(dbfile, (err, lookup) => {
+        if (err) {
+          reject(err);
+        } else {
+          console.log('--loaded');
+          resolve(lookup);
+        }
+      });
+    });
+  }
+}
+
+// sanity check ip addresses
+function cleanIp(ip) {
+  return (ip || '').split(',').map(s => s.trim())
+    .filter(s => s && s !== 'unknown')[0]
+}
+
+/**
+ * Lookup the geoid of the city geo name for an IP
+ */
+exports.look = (ipString) => {
+  return maxdb().then(
+    maxdb => {
+      let cleaned = cleanIp(ipString);
+      if (cleaned) {
+        let loc = maxdb.get(cleaned);
+        return {
+          city: (loc && loc.city) ? loc.city.geoname_id : null,
+          country: (loc && loc.country) ? loc.country.geoname_id : null
+        };
+      } else {
+        return {city: null, country: null};
+      }
+    },
+    err => {
+      console.error('Error loading maxmind db:', err);
+      return {city: null, country: null};
+    }
+  );
+};
+
+/**
+ * Get the YYYYMMDD date string for a timestamp
+ */
+exports.toDateString = (timestamp) => {
+  let iso = new Date(exports.toEpochSeconds(timestamp) * 1000).toISOString();
+  return iso.replace(/(-)|(T.+)/g, '');
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "Process kinesis metric streams and ship to bigquery",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node bin/getmaxmind.js",
     "start": "node-lambda run -j test/support/test-event.json",
     "test": "mocha test/",
     "ci": "istanbul cover _mocha -- test/ && codecov",
@@ -38,11 +39,13 @@
     "mocha": "^3.2.0",
     "node-lambda": "^0.8.13",
     "sinon": "^1.17.7",
-    "sinon-chai": "^2.9.0"
+    "sinon-chai": "^2.9.0",
+    "targz": "^1.0.1"
   },
   "dependencies": {
     "@google-cloud/bigquery": "^0.7.0",
     "aws-sdk": "^2.19.0",
+    "maxmind": "^2.2.0",
     "uuid": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dotenv": "^4.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
-    "node-lambda": "^0.8.13",
+    "node-lambda": "0.8.13",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.9.0",
     "targz": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Process kinesis metric streams and ship to bigquery",
   "main": "index.js",
   "scripts": {
-    "postinstall": "node bin/getmaxmind.js",
+    "geolite": "node bin/getmaxmind.js",
     "start": "node-lambda run -j test/support/test-event.json",
     "test": "mocha test/",
     "ci": "istanbul cover _mocha -- test/ && codecov",
@@ -45,7 +45,6 @@
   "dependencies": {
     "@google-cloud/bigquery": "^0.7.0",
     "aws-sdk": "^2.19.0",
-    "maxmind": "^2.2.0",
-    "uuid": "^3.0.1"
+    "maxmind": "^2.2.0"
   }
 }

--- a/test/inputs-dovetail-download-test.js
+++ b/test/inputs-dovetail-download-test.js
@@ -19,25 +19,28 @@ describe('dovetail-download', () => {
   });
 
   it('formats table inserts', () => {
-    let row = download.format({requestUuid: 'the-uuid', timestamp: 1490827132999});
-    expect(row).to.have.keys('insertId', 'json');
-    expect(row.insertId).to.equal('the-uuid');
-    expect(row.json).to.have.keys(
-      'digest',
-      'program',
-      'path',
-      'feeder_podcast',
-      'feeder_episode',
-      'remote_agent',
-      'remote_ip',
-      'timestamp',
-      'request_uuid',
-      'ad_count',
-      'is_duplicate',
-      'cause'
-    );
-    expect(row.json.timestamp).to.equal(1490827132);
-    expect(row.json.request_uuid).to.equal('the-uuid');
+    return download.format({requestUuid: 'the-uuid', timestamp: 1490827132999}).then(row => {
+      expect(row).to.have.keys('insertId', 'json');
+      expect(row.insertId).to.equal('the-uuid');
+      expect(row.json).to.have.keys(
+        'digest',
+        'program',
+        'path',
+        'feeder_podcast',
+        'feeder_episode',
+        'remote_agent',
+        'remote_ip',
+        'timestamp',
+        'request_uuid',
+        'ad_count',
+        'is_duplicate',
+        'cause',
+        'city_id',
+        'country_id'
+      );
+      expect(row.json.timestamp).to.equal(1490827132);
+      expect(row.json.request_uuid).to.equal('the-uuid');
+    });
   });
 
 });

--- a/test/inputs-dovetail-impression-test.js
+++ b/test/inputs-dovetail-impression-test.js
@@ -21,29 +21,32 @@ describe('dovetail-impression', () => {
   });
 
   it('formats table inserts', () => {
-    let row = impression.format({requestUuid: 'the-uuid', timestamp: 1490827132999});
-    expect(row).to.have.keys('insertId', 'json');
-    expect(row.insertId).not.to.equal('the-uuid');
-    expect(row.insertId.length).to.equal(36);
-    expect(row.json).to.have.keys(
-      'digest',
-      'program',
-      'path',
-      'feeder_podcast',
-      'feeder_episode',
-      'remote_agent',
-      'remote_ip',
-      'timestamp',
-      'request_uuid',
-      'ad_id',
-      'campaign_id',
-      'creative_id',
-      'flight_id',
-      'is_duplicate',
-      'cause'
-    );
-    expect(row.json.timestamp).to.equal(1490827132);
-    expect(row.json.request_uuid).to.equal('the-uuid');
+    return impression.format({requestUuid: 'the-uuid', timestamp: 1490827132999}).then(row => {
+      expect(row).to.have.keys('insertId', 'json');
+      expect(row.insertId).not.to.equal('the-uuid');
+      expect(row.insertId.length).to.equal(36);
+      expect(row.json).to.have.keys(
+        'digest',
+        'program',
+        'path',
+        'feeder_podcast',
+        'feeder_episode',
+        'remote_agent',
+        'remote_ip',
+        'timestamp',
+        'request_uuid',
+        'ad_id',
+        'campaign_id',
+        'creative_id',
+        'flight_id',
+        'is_duplicate',
+        'cause',
+        'city_id',
+        'country_id'
+      );
+      expect(row.json.timestamp).to.equal(1490827132);
+      expect(row.json.request_uuid).to.equal('the-uuid');
+    });
   });
 
 });

--- a/test/inputs-dovetail-impression-test.js
+++ b/test/inputs-dovetail-impression-test.js
@@ -24,7 +24,6 @@ describe('dovetail-impression', () => {
     return impression.format({requestUuid: 'the-uuid', timestamp: 1490827132999}).then(row => {
       expect(row).to.have.keys('insertId', 'json');
       expect(row.insertId).not.to.equal('the-uuid');
-      expect(row.insertId.length).to.equal(36);
       expect(row.json).to.have.keys(
         'digest',
         'program',
@@ -46,6 +45,20 @@ describe('dovetail-impression', () => {
       );
       expect(row.json.timestamp).to.equal(1490827132);
       expect(row.json.request_uuid).to.equal('the-uuid');
+    });
+  });
+
+  it('creates unique insert ids for ads', () => {
+    let formats = [
+      impression.format({requestUuid: 'req1', adId: 1}),
+      impression.format({requestUuid: 'req1', adId: 1}),
+      impression.format({requestUuid: 'req1', adId: 2}),
+      impression.format({requestUuid: 'req2', adId: 1})
+    ];
+    return Promise.all(formats).then(datas => {
+      expect(datas[0].insertId).to.equal(datas[1].insertId);
+      expect(datas[0].insertId).not.to.equal(datas[2].insertId);
+      expect(datas[0].insertId).not.to.equal(datas[3].insertId);
     });
   });
 

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -17,17 +17,17 @@ describe('inputs', () => {
     expect(inputs.tables).to.contain('the_downloads_table$19700101');
     expect(inputs.tables).to.contain('the_impressions_table$19700101');
 
-    expect(inputs.outputs.length).to.equal(2);
-    expect(inputs.outputs[0][0]).to.equal('the_impressions_table$19700101');
-    expect(inputs.outputs[0][1].length).to.equal(3);
-    expect(inputs.outputs[0][1][0].json.request_uuid).to.equal('i1');
-    expect(inputs.outputs[0][1][1].json.request_uuid).to.equal('i2');
-    expect(inputs.outputs[0][1][2].json.request_uuid).to.equal('i3');
-
-    expect(inputs.outputs[1][0]).to.equal('the_downloads_table$19700101');
-    expect(inputs.outputs[1][1].length).to.equal(2);
-    expect(inputs.outputs[1][1][0].json.request_uuid).to.equal('d1');
-    expect(inputs.outputs[1][1][1].json.request_uuid).to.equal('d2');
+    return inputs.formatRecords().then(recs => {
+      let downs = recs.find(r => r[0] === 'the_downloads_table$19700101')[1];
+      let imps = recs.find(r => r[0] === 'the_impressions_table$19700101')[1];
+      expect(downs.length).to.equal(2);
+      expect(downs[0].json.request_uuid).to.equal('d1');
+      expect(downs[1].json.request_uuid).to.equal('d2');
+      expect(imps.length).to.equal(3);
+      expect(imps[0].json.request_uuid).to.equal('i1');
+      expect(imps[1].json.request_uuid).to.equal('i2');
+      expect(imps[2].json.request_uuid).to.equal('i3');
+    });
   });
 
   it('groups records by date', () => {
@@ -41,13 +41,17 @@ describe('inputs', () => {
     expect(inputs.tables).to.contain('the_impressions_table$20170329');
     expect(inputs.tables).to.contain('the_impressions_table$20170330');
 
-    expect(inputs.outputs.length).to.equal(3);
-    expect(inputs.outputs[0][0]).to.equal('the_impressions_table$20170329');
-    expect(inputs.outputs[0][1][0].json.request_uuid).to.equal('i1');
-    expect(inputs.outputs[1][0]).to.equal('the_downloads_table$20170329');
-    expect(inputs.outputs[1][1][0].json.request_uuid).to.equal('d1');
-    expect(inputs.outputs[2][0]).to.equal('the_impressions_table$20170330');
-    expect(inputs.outputs[2][1][0].json.request_uuid).to.equal('i2');
+    return inputs.formatRecords().then(recs => {
+      let downs = recs.find(r => r[0] === 'the_downloads_table$20170329')[1];
+      let imps1 = recs.find(r => r[0] === 'the_impressions_table$20170329')[1];
+      let imps2 = recs.find(r => r[0] === 'the_impressions_table$20170330')[1];
+      expect(downs.length).to.equal(1);
+      expect(downs[0].json.request_uuid).to.equal('d1');
+      expect(imps1.length).to.equal(1);
+      expect(imps1[0].json.request_uuid).to.equal('i1');
+      expect(imps2.length).to.equal(1);
+      expect(imps2[0].json.request_uuid).to.equal('i2');
+    });
   });
 
   it('handles unrecognized records', () => {

--- a/test/lookip-test.js
+++ b/test/lookip-test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const support   = require('./support');
+const lookip = require('../lib/lookip');
+
+describe('lookip', () => {
+
+  it('looks up geoname ids for city and country', () => {
+    return lookip.look('66.6.44.4').then(look => {
+      expect(look.city).to.equal(5128581);
+      expect(look.country).to.equal(6252001);
+    });
+  });
+
+  it('handle unlocate-able ips', () => {
+    return lookip.look('192.168.0.1').then(look => {
+      expect(look.city).to.be.null;
+      expect(look.country).to.be.null;
+    });
+  });
+
+  it('handle blanks', () => {
+    return lookip.look('').then(look => {
+      expect(look.city).to.be.null;
+      expect(look.country).to.be.null;
+    });
+  });
+
+  it('handle nonsense', () => {
+    return lookip.look('ontehunteho').then(look => {
+      expect(look.city).to.be.null;
+      expect(look.country).to.be.null;
+    });
+  });
+
+  it('splits forwarded-for ips', () => {
+    return lookip.look('66.6.44.4, 99.99.99.99, 127.0.0.1').then(look => {
+      expect(look.city).to.equal(5128581);
+      expect(look.country).to.equal(6252001);
+    });
+  });
+
+  it('removes unknowns', () => {
+    return lookip.look('unknown,66.6.44.4').then(look => {
+      expect(look.city).to.equal(5128581);
+      expect(look.country).to.equal(6252001);
+    });
+  });
+
+  it('removes blanks', () => {
+    return lookip.look(', , 66.6.44.4 ,99.99.99.99').then(look => {
+      expect(look.city).to.equal(5128581);
+      expect(look.country).to.equal(6252001);
+    });
+  });
+
+});


### PR DESCRIPTION
Use maxmind to lookup city/country id for request IPs.  (Will have a separate lookup table of the string names of those places).

Sort of inclined to just nuke PR #4, and just review those changes here.

- [x] Include `city_id` and `country_id` columns, used against a geonames lookup table in BQ.
- [x] Retry bigquery inserts 3 times
- [x] Add a unique `insertId` to impressions, based on the request uuid and the ad id (assumes each ad will be served only once per arrangement)