### PR TITLE
Split redis into own function

### DIFF
--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -26,11 +26,11 @@ lambda._params = function(program, buffer) {
 };
 
 // deploy 2 functions, for bigquery-ingest vs pingbacks:
-const EXCLUDE = 'event.json .env env-example *.log .git .gitignore test';
-['analytics-ingest', 'analytics-pingback'].forEach(name => {
+const EXCLUDE = 'event.json .env env-example *.log logs .git .gitignore test tmp';
+['analytics-ingest', 'analytics-pingback', 'analytics-redis'].forEach(name => {
   let globs = EXCLUDE;
-  if (name === 'analytics-pingback') {
-    globs = `${globs} db`; // don't need maxmind db for pingbacks
+  if (name !== 'analytics-ingest') {
+    globs = `${globs} db`; // only biquery needs maxminddb
   }
   lambda.deploy({
     environment: envName,

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -10,36 +10,25 @@ const RedisIncrements = require('./redis-increments');
 /**
  * Delegate input parsers
  */
-module.exports = class Inputs {
+class Inputs {
 
-  constructor(records, doPingbacks) {
-    this._types = [];
+  constructor(records/*, types */) {
+    this._types = [].slice.call(arguments, 1);
     this._unknowns = [];
 
-    // do EITHER pingbacks or bigquery - NOT BOTH at the same time, as the
-    // kinesis retry logic is different between them.
-    if (doPingbacks) {
-      this._types.push(new AdzerkImpressions(records));
-      this._types.push(new AdzerkPingbacks(records));
-      this._types.push(new DovetailDownloads());
-      this._types.push(new DovetailImpressions());
-      this._types.push(new RedisIncrements(records));
-    } else {
-      this._types.push(new AdzerkImpressions());
-      this._types.push(new AdzerkPingbacks());
-      this._types.push(new DovetailDownloads(records));
-      this._types.push(new DovetailImpressions(records));
-      this._types.push(new RedisIncrements());
-    }
-
-    // find records not recognized by any input type
-    if (records) {
-      records.forEach(r => {
-        if (!this._types.some(t => t.check(r))) {
-          this._unknowns.push(r);
-        }
-      });
-    }
+    // check for unrecognized records
+    const allTypes = [
+      new AdzerkImpressions(),
+      new AdzerkPingbacks(),
+      new DovetailDownloads(),
+      new DovetailImpressions(),
+      new RedisIncrements()
+    ];
+    records.forEach(r => {
+      if (!allTypes.some(t => t.check(r))) {
+        this._unknowns.push(r);
+      }
+    });
   }
 
   get unrecognized() {
@@ -47,12 +36,35 @@ module.exports = class Inputs {
   }
 
   insertAll() {
-    return Promise.all(this._types.map(t => t.insert())).then(results => {
-      return results.reduce((a, b) => a.concat(b), []).map(r => {
-        logger.info(`Inserted ${r.count} rows into ${r.dest}`);
-        return r;
+    if (this._types.length) {
+      return Promise.all(this._types.map(t => t.insert())).then(results => {
+        return results.reduce((a, b) => a.concat(b), []).map(r => {
+          logger.info(`Inserted ${r.count} rows into ${r.dest}`);
+          return r;
+        });
       });
-    });
+    } else {
+      return Promise.resolve([]);
+    }
   }
 
+}
+
+/**
+ * Actual input groupings
+ */
+module.exports.BigqueryInputs = class BigqueryInputs extends Inputs {
+  constructor(records) {
+    super(records, new DovetailDownloads(records), new DovetailImpressions(records));
+  }
+}
+module.exports.PingbackInputs = class PingbackInputs extends Inputs {
+  constructor(records) {
+    super(records, new AdzerkImpressions(records), new AdzerkPingbacks(records));
+  }
+}
+module.exports.RedisInputs = class RedisInputs extends Inputs {
+  constructor(records) {
+    super(records, new RedisIncrements(records));
+  }
 }

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -8,11 +8,13 @@ const DovetailImpressions = require('./dovetail-impressions');
 const RedisIncrements = require('./redis-increments');
 
 /**
- * Delegate input parsers
+ * Abstract "Inputs" parser class.  Groups together input-types, and insert()s
+ * them in parallel.  Can be called with any number of input-types, as defined
+ * in the actual class exports at the bottom of this file.
  */
 class Inputs {
 
-  constructor(records/*, types */) {
+  constructor(records) {
     this._types = [].slice.call(arguments, 1);
     this._unknowns = [];
 

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const support = require('./support');
-const Inputs  = require('../lib/inputs');
+const { BigqueryInputs, PingbackInputs, RedisInputs } = require('../lib/inputs');
 const bigquery = require('../lib/bigquery');
 const logger = require('../lib/logger');
 
 describe('inputs', () => {
 
   it('handles unrecognized records', () => {
-    let inputs = new Inputs([
+    let inputs = new BigqueryInputs([
       {type: 'impression', requestUuid: 'i1', timestamp: 0},
       {type: 'foobar',     requestUuid: 'fb', timestamp: 0},
       {type: 'impression', requestUuid: 'i2', timestamp: 0},
@@ -22,7 +22,7 @@ describe('inputs', () => {
   it('inserts all bigquery inputs', () => {
     sinon.stub(logger, 'info');
     sinon.stub(bigquery, 'insert', (tbl, rows) => Promise.resolve(rows.length));
-    let inputs = new Inputs([
+    let inputs = new BigqueryInputs([
       {type: 'impression', requestUuid: 'i1', timestamp: 0, impressionUrl: 'http://foo.bar'},
       {type: 'foobar',     requestUuid: 'fb', timestamp: 0},
       {type: 'download',   requestUuid: 'd1', timestamp: 0},
@@ -42,7 +42,7 @@ describe('inputs', () => {
   it('inserts adzerk impression inputs', () => {
     sinon.stub(logger, 'info');
     nock('http://foo.bar').get('/').reply(200);
-    let inputs = new Inputs([
+    let inputs = new PingbackInputs([
       {type: 'impression', requestUuid: 'i1', timestamp: 0, impressionUrl: 'http://foo.bar'},
       {type: 'foobar',     requestUuid: 'fb', timestamp: 0},
       {type: 'download',   requestUuid: 'd1', timestamp: 0},
@@ -58,7 +58,7 @@ describe('inputs', () => {
   it('inserts adzerk pingback inputs', () => {
     sinon.stub(logger, 'info');
     nock('http://foo.bar').get('/i1').reply(200);
-    let inputs = new Inputs([
+    let inputs = new PingbackInputs([
       {requestUuid: 'i1', pingbacks: ['http://foo.bar/{uuid}']},
       {requestUuid: 'i2', pingbacks: ['http://bar.foo/{uuid}'], isDuplicate: true},
       {requestUuid: 'i3'}
@@ -73,7 +73,7 @@ describe('inputs', () => {
   it('inserts redis increment inputs', () => {
     process.env.REDIS_HOST = 'whatev';
     sinon.stub(logger, 'info');
-    let inputs = new Inputs([
+    let inputs = new RedisInputs([
       {type: 'impression', feederPodcast: 1, timestamp: 0},
       {type: 'foobar',     feederPodcast: 1, timestamp: 0},
       {type: 'download',   feederPodcast: 1, timestamp: 0},

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -30,7 +30,11 @@
     "creativeId": 56,
     "flightId": 78,
     "isDuplicate": false,
-    "cause": null
+    "cause": null,
+    "pingbacks": [
+      "http://www.foo.bar/ping1",
+      "http://www.foo.bar/ping2"
+    ]
   },
   {
     "foo": "bar"
@@ -51,7 +55,8 @@
     "creativeId": 56,
     "flightId": 78,
     "isDuplicate": true,
-    "cause": "something"
+    "cause": "something",
+    "impressionUrl": "http://www.foo.bar/ping3"
   },
   {
     "type": "impression",
@@ -69,6 +74,7 @@
     "creativeId": 56,
     "flightId": 78,
     "isDuplicate": false,
-    "cause": null
+    "cause": null,
+    "impressionUrl": "http://www.foo.bar/ping4"
   }
 ]


### PR DESCRIPTION
Turns out, it's not easy to both (1) run a lambda in a VPC with access to Elasticache/Redis, and (2) also have outgoing access to the wider web from that function.  This is due to lambdas, unlike ec2 instances, not having a public IP address.  There are workarounds, but they're all way harder than just splitting the function up.

So this gives us yet-another `analytics-redis-staging` function, that will subscribe to the same kinesis streams as `analytics-ingest-staging` and `analytics-pingbacks-staging`.

We're nowhere near our read-rate-limit on kinesis shards, so should be fine on that front.