### PR TITLE
Parameter store

### DIFF
--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -9,7 +9,8 @@ let _cachedDataset;
  */
 exports.dataset = (forceRefresh) => {
   if (forceRefresh || !_cachedDataset) {
-    let keyPromise;
+    let key = process.env.BQ_PRIVATE_KEY || '';
+    let keyPromise = Promise.resolve(key.replace(/\\n/g, '\n'));
 
     // the key may be encrypted out in aws - note that decrypted keys will come
     // out a bit funky, with their newlines encoded
@@ -17,9 +18,6 @@ exports.dataset = (forceRefresh) => {
       keyPromise = decrypt.decryptAws(process.env.BQ_PRIVATE_KEY).then(decrypted => {
         return process.env.BQ_PRIVATE_KEY = decrypted.replace(/\\n/g, '\n');
       });
-    } else {
-      let key = process.env.BQ_PRIVATE_KEY || '';
-      keyPromise = Promise.resolve(key.replace(/\\n/g, '\n'));
     }
 
     return keyPromise.then(key => {

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -9,7 +9,7 @@ let _cachedDataset;
  */
 exports.dataset = (forceRefresh) => {
   if (forceRefresh || !_cachedDataset) {
-    let keyPromise = Promise.resolve(process.env.BQ_PRIVATE_KEY);
+    let keyPromise;
 
     // the key may be encrypted out in aws - note that decrypted keys will come
     // out a bit funky, with their newlines encoded
@@ -17,6 +17,9 @@ exports.dataset = (forceRefresh) => {
       keyPromise = decrypt.decryptAws(process.env.BQ_PRIVATE_KEY).then(decrypted => {
         return process.env.BQ_PRIVATE_KEY = decrypted.replace(/\\n/g, '\n');
       });
+    } else {
+      let key = process.env.BQ_PRIVATE_KEY || '';
+      keyPromise = Promise.resolve(key.replace(/\\n/g, '\n'));
     }
 
     return keyPromise.then(key => {

--- a/lib/loadenv.js
+++ b/lib/loadenv.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const ssm = new AWS.SSM({region: process.env.AWS_REGION || 'us-east-1'});
+const logger = require('./logger');
+
+// only load params once
+let PARAMS_LOADED = false;
+
+/**
+ * Bootstrap parameter-store into the process.env
+ */
+exports.load = (callback, nextToken) => {
+  if (process.env.PARAMSTORE_PREFIX) {
+    if (PARAMS_LOADED) {
+      return callback();
+    } else {
+      getParameters(params => {
+        params.forEach(param => {
+          let key = param.Name.split('/').pop();
+          process.env[key] = param.Value;
+        });
+        PARAMS_LOADED = true;
+        callback();
+      });
+    }
+  } else {
+    callback();
+  }
+}
+
+/**
+ * SSM calls, logging/ignoring errors
+ */
+function getParameters(callback, prevResults, nextToken) {
+  prevResults = prevResults || [];
+   let params = {Path: process.env.PARAMSTORE_PREFIX, WithDecryption: true};
+   if (nextToken) {
+     params.NextToken = nextToken;
+   }
+   ssm.getParametersByPath(params, (err, data) => {
+     if (err) {
+       logger.error(`SSM Error: ${err}`);
+       callback(prevResults);
+     } else if (data.NextToken) {
+       getParameters(callback, data.Parameters.concat(prevResults), data.NextToken);
+     } else {
+       callback(data.Parameters.concat(prevResults));
+     }
+   });
+ }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "main": "index.js",
   "scripts": {
     "geolite": "node bin/getmaxmind.js",
-    "start": "npm run start-bigquery && npm run start-pingbacks",
-    "start-bigquery": "PINGBACKS=0 node test/integration/runner.js",
-    "start-pingbacks": "PINGBACKS=1 node test/integration/runner.js",
+    "start": "npm run start-bigquery && npm run start-pingbacks && npm run start-redis",
+    "start-bigquery": "PINGBACKS=0 REDIS_HOST=0 node test/integration/runner.js",
+    "start-pingbacks": "PINGBACKS=1 REDIS_HOST=0 node test/integration/runner.js",
+    "start-redis": "PINGBACKS=0 node test/integration/runner.js",
     "test": "mocha test/",
     "ci": "istanbul cover _mocha -- test/ && codecov",
     "build": "npm run build-sync && npm run build-prune && npm run build-zip",

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -8,11 +8,16 @@ const index     = require('../../index');
 const handler   = index.handler;
 
 // decode pingback settings
-if (!process.env.PINGBACKS || process.env.PINGBACKS === '0') {
+if (process.env.REDIS_HOST && process.env.REDIS_HOST !== '0') {
   delete process.env.PINGBACKS;
-  console.log('Running BIGQUERY');
-} else {
+  console.log('Running REDIS');
+} else if (process.env.PINGBACKS && process.env.PINGBACKS !== '0') {
+  delete process.env.REDIS_HOST;
   console.log('Running PINGBACKS');
+} else {
+  delete process.env.PINGBACKS;
+  delete process.env.REDIS_HOST;
+  console.log('Running BIGQUERY');
 }
 
 /**


### PR DESCRIPTION
Optionally load _some_ ENVs from the parameter store.

- Add a `PARAMSTORE_PREFIX` param, which will be set to something like `/prx/analytics-redis`. 
 Though this function doesn't actually care what scheme we use for the prefix.
- Any set parameters under the PREFIX will be loaded into the environment:
  - `/prx/analytics-redis/REDIS_HOST` will be loaded, as in `REDIS_HOST=the-value`
  - `/prx/analytics-redis/another-level/REDIS_HOST` will **_not_** be loaded
- Param-store loaded ENVs will have precedence over local (lambda-configured) ENVs
- Values will be decrypted by the aws-sdk call, so make sure the lambda has access to the correct kms keys!

Eventually, should be able to remove all the kms/decrypt code from this function.  But I left it in for now, since we're keeping the old non-CloudFormation functions deployable until we switch the kinesis triggers over.