### PR TITLE
Less redis increments

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -24,17 +24,11 @@ module.exports = class Redis {
     } else {
       epoch = timestamp.toEpochSeconds(dtim.getTime());
     }
-    let fifteen = epoch - (epoch % 900);
     let hour = epoch - (epoch % 3600);
     let day = epoch - (epoch % 86400);
-    let week = beginningOfWeek(dtim, day);
-    let month = beginningOfMonth(dtim, day);
     return [
-      '15MIN.' + timestamp.toISOExtendedZ(fifteen),
       'HOUR.' + timestamp.toISOExtendedZ(hour),
       'DAY.' + timestamp.toISOExtendedZ(day),
-      'WEEK.' + timestamp.toISOExtendedZ(week),
-      'MONTH.' + timestamp.toISOExtendedZ(month)
     ];
   }
 
@@ -97,12 +91,4 @@ module.exports = class Redis {
     });
   }
 
-}
-
-// helpers
-function beginningOfWeek(dtim, beginningOfDayEpoch) {
-  return beginningOfDayEpoch - dtim.getUTCDay() * 86400;
-}
-function beginningOfMonth(dtim, beginningOfDayEpoch) {
-  return beginningOfDayEpoch - (dtim.getUTCDate() - 1) * 86400;
 }

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -179,7 +179,7 @@ describe('handler', () => {
     handler(event, null, (err, result) => {
       expect(warns.length).to.equal(0);
       expect(errs.length).to.equal(1);
-      expect(result).to.match(/inserted 30/i);
+      expect(result).to.match(/inserted 12/i);
 
       let keys = [
         support.redisKeys('downloads.episodes.*'),
@@ -188,10 +188,10 @@ describe('handler', () => {
         support.redisKeys('impressions.podcasts.*')
       ];
       Promise.all(keys).then(all => {
-        expect(all[0].length).to.equal(5);
-        expect(all[1].length).to.equal(5);
-        expect(all[2].length).to.equal(8);
-        expect(all[3].length).to.equal(8);
+        expect(all[0].length).to.equal(2);
+        expect(all[1].length).to.equal(2);
+        expect(all[2].length).to.equal(4);
+        expect(all[3].length).to.equal(4);
         done();
       });
     });

--- a/test/inputs-redis-increments-test.js
+++ b/test/inputs-redis-increments-test.js
@@ -55,44 +55,33 @@ describe('redis-increments', () => {
       record(1490827132, 'download', 1234, 'abcd'),
       record(1490827132, 'download', 1234, 'efgh'),
       record(1490828132, 'download', 1234, 'abcd'),
+      record(1490829132, 'download', 1234, 'abcd'),
       record(1490827132, 'impression', 1234, null),
       record(1490827132, 'impression', 1234, 'efgh', true)
     ]);
     return incr.insert().then(result => {
       expect(result.length).to.equal(1);
       expect(result[0].dest).to.equal('redis://127.0.0.1');
-      expect(result[0].count).to.equal(4 * 5 + 3 * 5); // skips null episode impression
+      expect(result[0].count).to.equal(4 * 4 + 1 * 2); // skips null episode impression
       return support.redisGetAll('downloads.podcasts.*');
     }).then(vals => {
-      expect(Object.keys(vals).length).to.equal(6);
-      expect(vals['downloads.podcasts.15MIN.2017-03-29T22:30:00Z']['1234']).to.equal('2');
-      expect(vals['downloads.podcasts.15MIN.2017-03-29T22:45:00Z']['1234']).to.equal('1');
+      expect(Object.keys(vals).length).to.equal(3);
       expect(vals['downloads.podcasts.HOUR.2017-03-29T22:00:00Z']['1234']).to.equal('3');
-      expect(vals['downloads.podcasts.DAY.2017-03-29T00:00:00Z']['1234']).to.equal('3');
-      expect(vals['downloads.podcasts.WEEK.2017-03-26T00:00:00Z']['1234']).to.equal('3');
-      expect(vals['downloads.podcasts.MONTH.2017-03-01T00:00:00Z']['1234']).to.equal('3');
+      expect(vals['downloads.podcasts.HOUR.2017-03-29T23:00:00Z']['1234']).to.equal('1');
+      expect(vals['downloads.podcasts.DAY.2017-03-29T00:00:00Z']['1234']).to.equal('4');
       return support.redisGetAll('impressions.podcasts.*');
     }).then(vals => {
-      expect(Object.keys(vals).length).to.equal(5);
-      expect(vals['impressions.podcasts.15MIN.2017-03-29T22:30:00Z']['1234']).to.equal('1');
+      expect(Object.keys(vals).length).to.equal(2);
       expect(vals['impressions.podcasts.HOUR.2017-03-29T22:00:00Z']['1234']).to.equal('1');
       expect(vals['impressions.podcasts.DAY.2017-03-29T00:00:00Z']['1234']).to.equal('1');
-      expect(vals['impressions.podcasts.WEEK.2017-03-26T00:00:00Z']['1234']).to.equal('1');
-      expect(vals['impressions.podcasts.MONTH.2017-03-01T00:00:00Z']['1234']).to.equal('1');
       return support.redisGetAll('downloads.episodes.*');
     }).then(vals => {
-      expect(Object.keys(vals).length).to.equal(6);
-      expect(vals['downloads.episodes.15MIN.2017-03-29T22:30:00Z']['abcd']).to.equal('1');
-      expect(vals['downloads.episodes.15MIN.2017-03-29T22:30:00Z']['efgh']).to.equal('1');
-      expect(vals['downloads.episodes.15MIN.2017-03-29T22:45:00Z']['abcd']).to.equal('1');
+      expect(Object.keys(vals).length).to.equal(3);
       expect(vals['downloads.episodes.HOUR.2017-03-29T22:00:00Z']['abcd']).to.equal('2');
       expect(vals['downloads.episodes.HOUR.2017-03-29T22:00:00Z']['efgh']).to.equal('1');
-      expect(vals['downloads.episodes.DAY.2017-03-29T00:00:00Z']['abcd']).to.equal('2');
+      expect(vals['downloads.episodes.HOUR.2017-03-29T23:00:00Z']['abcd']).to.equal('1');
+      expect(vals['downloads.episodes.DAY.2017-03-29T00:00:00Z']['abcd']).to.equal('3');
       expect(vals['downloads.episodes.DAY.2017-03-29T00:00:00Z']['efgh']).to.equal('1');
-      expect(vals['downloads.episodes.WEEK.2017-03-26T00:00:00Z']['abcd']).to.equal('2');
-      expect(vals['downloads.episodes.WEEK.2017-03-26T00:00:00Z']['efgh']).to.equal('1');
-      expect(vals['downloads.episodes.MONTH.2017-03-01T00:00:00Z']['abcd']).to.equal('2');
-      expect(vals['downloads.episodes.MONTH.2017-03-01T00:00:00Z']['efgh']).to.equal('1');
       return support.redisGetAll('impressions.episodes.*');
     }).then(vals => {
       expect(Object.keys(vals).length).to.equal(0);
@@ -106,10 +95,10 @@ describe('redis-increments', () => {
     return incr.insert().then(result => {
       expect(result.length).to.equal(1);
       expect(result[0].dest).to.equal('redis://127.0.0.1');
-      expect(result[0].count).to.equal(2 * 5);
+      expect(result[0].count).to.equal(2 * 2);
       return support.redisTTLAll('downloads.*');
     }).then(ttlMap => {
-      expect(Object.keys(ttlMap).length).to.equal(10);
+      expect(Object.keys(ttlMap).length).to.equal(4);
       Object.keys(ttlMap).forEach(key => {
         expect(ttlMap[key]).to.equal(7200);
       });

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -81,7 +81,7 @@ describe('inputs', () => {
     ], true);
     return inputs.insertAll().then(inserts => {
       expect(inserts.length).to.equal(1);
-      expect(inserts[0].count).to.equal(15);
+      expect(inserts[0].count).to.equal(6);
       expect(inserts[0].dest).to.equal('redis://whatev');
     });
   });

--- a/test/redis-test.js
+++ b/test/redis-test.js
@@ -11,30 +11,27 @@ describe('redis', () => {
 
   it('generates date keys', () => {
     let keys = Redis.keys(new Date('2017-10-26T17:26:28Z'));
-    expect(keys.length).to.equal(5);
-    expect(keys[0]).to.equal('15MIN.2017-10-26T17:15:00Z');
-    expect(keys[1]).to.equal('HOUR.2017-10-26T17:00:00Z');
-    expect(keys[2]).to.equal('DAY.2017-10-26T00:00:00Z');
-    expect(keys[3]).to.equal('WEEK.2017-10-22T00:00:00Z');
-    expect(keys[4]).to.equal('MONTH.2017-10-01T00:00:00Z');
+    expect(keys.length).to.equal(2);
+    expect(keys[0]).to.equal('HOUR.2017-10-26T17:00:00Z');
+    expect(keys[1]).to.equal('DAY.2017-10-26T00:00:00Z');
   });
 
-  it('gets the beginning of week correctly', () => {
-    let key = Redis.keys(new Date('2017-10-22T00:00:01Z'))[3];
-    expect(key).to.equal('WEEK.2017-10-22T00:00:00Z');
-    key = Redis.keys(new Date('2017-10-22T00:00:00Z'))[3];
-    expect(key).to.equal('WEEK.2017-10-22T00:00:00Z');
-    key = Redis.keys(new Date('2017-10-21T23:59:59Z'))[3];
-    expect(key).to.equal('WEEK.2017-10-15T00:00:00Z');
+  it('gets the beginning of hour correctly', () => {
+    let key = Redis.keys(new Date('2017-10-22T00:00:01Z'))[0];
+    expect(key).to.equal('HOUR.2017-10-22T00:00:00Z');
+    key = Redis.keys(new Date('2017-10-22T00:00:00Z'))[0];
+    expect(key).to.equal('HOUR.2017-10-22T00:00:00Z');
+    key = Redis.keys(new Date('2017-10-21T23:59:59Z'))[0];
+    expect(key).to.equal('HOUR.2017-10-21T23:00:00Z');
   });
 
-  it('gets the beginning of month correctly', () => {
-    let key = Redis.keys(new Date('2017-10-01T00:00:01Z'))[4];
-    expect(key).to.equal('MONTH.2017-10-01T00:00:00Z');
-    key = Redis.keys(new Date('2017-10-01T00:00:00Z'))[4];
-    expect(key).to.equal('MONTH.2017-10-01T00:00:00Z');
-    key = Redis.keys(new Date('2017-09-30T23:59:59Z'))[4];
-    expect(key).to.equal('MONTH.2017-09-01T00:00:00Z');
+  it('gets the beginning of day correctly', () => {
+    let key = Redis.keys(new Date('2017-10-22T00:00:01Z'))[1];
+    expect(key).to.equal('DAY.2017-10-22T00:00:00Z');
+    key = Redis.keys(new Date('2017-10-22T00:00:00Z'))[1];
+    expect(key).to.equal('DAY.2017-10-22T00:00:00Z');
+    key = Redis.keys(new Date('2017-10-21T23:59:59Z'))[1];
+    expect(key).to.equal('DAY.2017-10-21T00:00:00Z');
   });
 
   it('gets scoped keys', () => {


### PR DESCRIPTION
Castle no longer uses the 15min / weekly / monthly rollup keys.  We dropped support for 15min, and opted to rollup days into weeks/months just-in-time.

So no longer need to INCR these keys.