### PR TITLE
Insert dovetail bytes into bigquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,43 @@ The lambda subscribes to kinesis streams, containing metric event records. These
 various metric records are either recognized by an input source in `lib/inputs`,
 or ignored and logged as a warning at the end of the lambda execution.
 
+Because of differences in (a) retry logic, or (b) VPC network access, this repo
+is actually deployed as 3 different lambdas.  But all are subscribed to the same
+kinesis streams, so they can move records to different destinations.
+
 ## BigQuery
 
-Records with type `download`/`impression` will be parsed into BigQuery table formats,
-and inserted into their corresponding BigQuery tables in parallel.  This is called
-[streaming inserts](https://cloud.google.com/bigquery/streaming-data-into-bigquery),
+Records with type `download`/`impression`/`bytes`/`segmentbytes` will be parsed
+into BigQuery table formats, and inserted into their corresponding BigQuery
+tables in parallel.  This is called [streaming inserts](https://cloud.google.com/bigquery/streaming-data-into-bigquery),
 and in case the insert fails, it will be attempted 2 more times before the Lambda
 fails with an error.  And since each insert includes a unique `insertId`, we
 don't have any data consistency issues with re-running the inserts.
 
-Because the timestamp on the metric may lag behind the lambda execution time,
-we also append the BigQuery date partition to the table name, eg
-`table_name$20170317`.
+BigQuery now supports partitioning based on a [specific timestamp field](https://cloud.google.com/bigquery/docs/partitioned-tables#partitioned_tables),
+so any inserts streamed to a table will be automatically moved to the correct
+daily partition.
 
 ## Pingbacks
 
-Non-duplicate records with a special `pingbacks` array will HTTP GET those URLs,
-expecting to land on a 200 response after redirects. Although 500 errors will
-be retried, any ping failures will be allowed to fail after error/timeout.
-Unlike BigQuery, these operations are not idempotent, so we don't want to
-over-ping a url.
+Records with type `download` and a special `pingbacks` array will be pinged via
+an HTTP GET.  This "ping" does follow redirects, but expects to land on a 200
+response afterwards.  Although 500 errors will be retried internally in the
+code, any ping failures will be allowed to fail after error/timeout.
 
-Similar to Pingbacks, any non-duplicate impression with an `impressionUrl` will
-be pinged.  This is normally the "official" Adzerk pixel-tracker from Dovetail.
+Unlike BigQuery, these operations are not idempotent, so we don't want to
+over-ping a url.  All errors will be handled internally so Kinesis doesn't
+attempt to re-exec the batch of records.
+
+Similarly, any non-duplicate impression with an `impressionUrl` will also be
+pinged.  This is normally the "official" Adzerk pixel-tracker from Dovetail.
 
 ## Redis
 
 To give some semblance of live metrics, this lambda can also directly `INCR`
 the Redis cache used by [castle.prx.org](https://github.com/PRX/castle.prx.org).
-This operates on both download and impression records, and like Pingbacks, will
-be allowed to fail without retry.
+This operates on type = `download` records, and like Pingbacks, will be allowed
+to fail without retry.
 
 # Installation
 
@@ -69,16 +76,11 @@ run pingbacks, add `PINGBACKS=true` to your `.env` file.
 
 # Deployment
 
-This repo actually represents 2 lambda functions: `analytics-ingest-ENVIRONMENT`
-to insert downloads/impressions into bigquery, and `analytics-pingback-ENVIRONMENT`
-to manage Adzerk impressions, other HTTP pingbacks, and realtime redis increments.
+The 3 lambdas functions are deployed via a Cloudformation stack in the [Infrastructure repo](https://github.com/PRX/Infrastructure/blob/master/stacks/analytics-ingest-lambda.yml):
 
-These need separate functions due to the retry logic of kinesis-triggered lambdas.
-If any errors are thrown, that same kinesis segment will be retried over and over,
-until they succeed or expire. For BigQuery, this is fine, since the `insertId`
-does some de-duping for us. But for pingbacks, we want to just allow these to
-fail without re-running the entire kinesis segment. This prevents one misbehaving
-pingback from causing a bunch of duplicates GETs on the rest of them.
+ - `AnalyticsBigqueryLambda` - insert downloads/impressions/bytes into BigQuery
+ - `AnalyticsPingbacksLambda` - ping Adzerk impressions and 3rd-party pingbacks
+ - `AnalyticsRedisLambda` - realtime Redis increments
 
 # Docker
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PRX Metrics Ingest
 
-Lambda to process metrics data from a kinesis stream, and stream inserts into
-one or more BigQuery tables.
+Lambda to process metrics data coming from one or more kinesis streams, and
+send that data to multiple destinations.
 
 # Description
 

--- a/lib/inputs/dovetail-bytes.js
+++ b/lib/inputs/dovetail-bytes.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const timestamp = require('../timestamp');
+const bigquery = require('../bigquery');
+
+/**
+ * Send dovetail downloads to bigquery
+ */
+module.exports = class DovetailDownloadBytes {
+
+  constructor(records) {
+    this._records = (records || []).filter(r => this.check(r));
+  }
+
+  check(record) {
+    return record.type === 'bytes' || record.type === 'segmentbytes';
+  }
+
+  insert() {
+    if (this._records.length == 0) {
+      return Promise.resolve([]);
+    } else {
+      let tables = {}
+      this._records.forEach(r => {
+        if (r.type === 'bytes') {
+          if (!tables.dt_download_bytes) {
+            tables.dt_download_bytes = []
+          }
+          tables.dt_download_bytes.push(this.formatDownload(r))
+        } else {
+          if (!tables.dt_impression_bytes) {
+            tables.dt_impression_bytes = []
+          }
+          tables.dt_impression_bytes.push(this.formatImpression(r))
+        }
+      })
+
+      // run per-table inserts in parallel
+      return Promise.all(Object.keys(tables).map(t => {
+        return bigquery.insert(t, tables[t]).then(num => {
+          return {count: num, dest: t};
+        });
+      }));
+    }
+  }
+
+  formatDownload(record) {
+    return {
+      insertId: `bytes-${record.request_uuid}`,
+      json: {
+        timestamp: timestamp.toEpochSeconds(record.timestamp || 0),
+        request_uuid: record.request_uuid,
+        bytes: record.bytes_downloaded,
+        seconds: record.seconds_downloaded,
+        percent: record.percent_downloaded
+      }
+    };
+  }
+
+  formatImpression(record) {
+    let formatted = this.formatDownload(record)
+    formatted.insertId = `${formatted.insertId}-${record.segment_index}`;
+    formatted.json.segment_index = record.segment_index;
+    return formatted;
+  }
+
+}

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -3,6 +3,7 @@
 const logger = require('../logger');
 const AdzerkImpressions = require('./adzerk-impressions');
 const AdzerkPingbacks = require('./adzerk-pingbacks');
+const DovetailBytes = require('./dovetail-bytes');
 const DovetailDownloads = require('./dovetail-downloads');
 const DovetailImpressions = require('./dovetail-impressions');
 const RedisIncrements = require('./redis-increments');
@@ -22,6 +23,7 @@ class Inputs {
     const allTypes = [
       new AdzerkImpressions(),
       new AdzerkPingbacks(),
+      new DovetailBytes(),
       new DovetailDownloads(),
       new DovetailImpressions(),
       new RedisIncrements()
@@ -57,7 +59,12 @@ class Inputs {
  */
 module.exports.BigqueryInputs = class BigqueryInputs extends Inputs {
   constructor(records) {
-    super(records, new DovetailDownloads(records), new DovetailImpressions(records));
+    super(
+      records,
+      new DovetailDownloads(records),
+      new DovetailImpressions(records),
+      new DovetailBytes(records)
+    );
   }
 }
 module.exports.PingbackInputs = class PingbackInputs extends Inputs {

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -70,10 +70,10 @@ describe('handler', () => {
     let event = support.buildEvent(require('./support/test-records'));
     handler(event, null, (err, result) => {
       expect(errs.length).to.equal(1);
-      expect(result).to.match(/inserted 4/i);
+      expect(result).to.match(/inserted 6/i);
 
       // based on test-records
-      expect(inserted).to.have.keys('dt_downloads', 'dt_impressions');
+      expect(inserted).to.have.keys('dt_downloads', 'dt_impressions', 'dt_download_bytes', 'dt_impression_bytes');
 
       expect(inserted['dt_downloads'].length).to.equal(1);
       expect(inserted['dt_downloads'][0].insertId).to.equal('req-uuid');
@@ -127,6 +127,27 @@ describe('handler', () => {
       expect(impressionJson.ad_id).to.equal(76);
       expect(impressionJson.is_duplicate).to.equal(false);
       expect(impressionJson.cause).to.equal(null);
+
+      expect(inserted['dt_download_bytes'].length).to.equal(1);
+      expect(inserted['dt_download_bytes'][0].insertId).not.to.equal('req-uuid');
+      expect(inserted['dt_download_bytes'][0].json).to.eql({
+        request_uuid: 'req-uuid',
+        timestamp: 1539287413,
+        bytes: 104820,
+        seconds: 2.5858585858,
+        percent: 0.582747737
+      });
+
+      expect(inserted['dt_impression_bytes'].length).to.equal(1);
+      expect(inserted['dt_impression_bytes'][0].insertId).not.to.equal('req-uuid');
+      expect(inserted['dt_impression_bytes'][0].json).to.eql({
+        request_uuid: 'req-uuid',
+        segment_index: 4,
+        timestamp: 1539287527,
+        bytes: 104820,
+        seconds: 2.5858585858,
+        percent: 0.582747737
+      });
 
       done();
     });

--- a/test/inputs-dovetail-bytes-test.js
+++ b/test/inputs-dovetail-bytes-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const support = require('./support');
+const bigquery = require('../lib/bigquery');
+const DovetailBytes = require('../lib/inputs/dovetail-bytes');
+
+describe('dovetail-bytes', () => {
+
+  let bytes = new DovetailBytes();
+
+  it('recognizes bytes records', () => {
+    expect(bytes.check({})).to.be.false;
+    expect(bytes.check({type: 'anything'})).to.be.false;
+    expect(bytes.check({type: 'bytes'})).to.be.true;
+    expect(bytes.check({type: 'segmentbytes'})).to.be.true;
+  });
+
+  it('formats download byte inserts', () => {
+    const record = bytes.formatDownload({
+      timestamp: 1490827132999,
+      request_uuid: 'the-uuid',
+      bytes_downloaded: 123,
+      seconds_downloaded: 1.23,
+      percent_downloaded: 0.12,
+    })
+    expect(record).to.have.keys('insertId', 'json');
+    expect(record.insertId).to.equal('bytes-the-uuid');
+    expect(record.json).to.have.keys('timestamp', 'request_uuid', 'bytes', 'seconds', 'percent');
+    expect(record.json.timestamp).to.equal(1490827132);
+    expect(record.json.request_uuid).to.equal('the-uuid');
+    expect(record.json.bytes).to.equal(123);
+    expect(record.json.seconds).to.equal(1.23);
+    expect(record.json.percent).to.equal(0.12);
+  });
+
+  it('formats impression byte inserts', () => {
+    const record = bytes.formatImpression({
+      timestamp: 1490827132999,
+      request_uuid: 'the-uuid',
+      segment_index: 2,
+      bytes_downloaded: 123,
+      seconds_downloaded: 1.23,
+      percent_downloaded: 0.12,
+    })
+    expect(record).to.have.keys('insertId', 'json');
+    expect(record.insertId).to.equal('bytes-the-uuid-2');
+    expect(record.json).to.have.keys('timestamp', 'request_uuid', 'segment_index', 'bytes', 'seconds', 'percent');
+    expect(record.json.timestamp).to.equal(1490827132);
+    expect(record.json.request_uuid).to.equal('the-uuid');
+    expect(record.json.segment_index).to.equal(2);
+    expect(record.json.bytes).to.equal(123);
+    expect(record.json.seconds).to.equal(1.23);
+    expect(record.json.percent).to.equal(0.12);
+  });
+
+  it('inserts nothing', () => {
+    return bytes.insert().then(result => {
+      expect(result.length).to.equal(0);
+    });
+  });
+
+  it('inserts byte records', () => {
+    let inserts = {};
+    sinon.stub(bigquery, 'insert', (tbl, rows) => {
+      inserts[tbl] = rows;
+      return Promise.resolve(rows.length);
+    });
+    const bytes2 = new DovetailBytes([
+      {type: 'bytes', request_uuid: 'the-uuid1', timestamp: 1490827132999},
+      {type: 'segmentbytes', request_uuid: 'the-uuid2', segment_index: 2, timestamp: 1490827132999},
+      {type: 'bytes', request_uuid: 'the-uuid3', timestamp: 1490837132},
+      {type: 'download', request_uuid: 'the-uuid4', timestamp: 1490827132999},
+    ]);
+    return bytes2.insert().then(result => {
+      expect(result.length).to.equal(2);
+      expect(result[0].dest).to.equal('dt_download_bytes');
+      expect(result[0].count).to.equal(2);
+      expect(result[1].dest).to.equal('dt_impression_bytes');
+      expect(result[1].count).to.equal(1);
+      expect(inserts['dt_download_bytes'].length).to.equal(2);
+      expect(inserts['dt_download_bytes'][0].json.request_uuid).to.equal('the-uuid1');
+      expect(inserts['dt_download_bytes'][1].json.request_uuid).to.equal('the-uuid3');
+      expect(inserts['dt_impression_bytes'].length).to.equal(1);
+      expect(inserts['dt_impression_bytes'][0].json.request_uuid).to.equal('the-uuid2');
+    });
+  });
+
+});

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -26,13 +26,17 @@ describe('inputs', () => {
       {type: 'impression', requestUuid: 'i1', timestamp: 0, impressionUrl: 'http://foo.bar'},
       {type: 'foobar',     requestUuid: 'fb', timestamp: 0},
       {type: 'download',   requestUuid: 'd1', timestamp: 0},
-      {type: 'impression', requestUuid: 'i2', timestamp: 999999}
+      {type: 'impression', requestUuid: 'i2', timestamp: 999999},
+      {type: 'segmentbytes', requestUuid: 'b1', timestamp: 999999},
+      {type: 'bytes',        requestUuid: 'b2', timestamp: 999999}
     ]);
     return inputs.insertAll().then(inserts => {
-      expect(inserts.length).to.equal(2);
-      expect(inserts.map(i => i.count)).to.eql([1, 2]);
+      expect(inserts.length).to.equal(4);
+      expect(inserts.map(i => i.count)).to.eql([1, 2, 1, 1]);
       expect(inserts.map(i => i.dest).sort()).to.eql([
+        'dt_download_bytes',
         'dt_downloads',
+        'dt_impression_bytes',
         'dt_impressions'
       ]);
     });

--- a/test/support/test-event.json
+++ b/test/support/test-event.json
@@ -63,6 +63,38 @@
       "invokeIdentityArn": "arn:aws:iam::561178107736:role/lambda_kinesis_execution",
       "awsRegion": "us-east-1",
       "eventSourceARN": "arn:aws:kinesis:us-east-1:561178107736:stream/dovetail-metrics-production-6s"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "uh84huoedu74d43hu9o8eidbk8o9e74d",
+        "sequenceNumber": "59558266616753302169815546155894738867705645161305342034",
+        "data": "eyJ0eXBlIjoiYnl0ZXMiLCJ0aW1lc3RhbXAiOjE1MzkyODc0MTM2MTcsInJlcXVlc3RfdXVpZCI6InJlcS11dWlkIiwiYnl0ZXNfZG93bmxvYWRlZCI6MTA0ODIwLCJzZWNvbmRzX2Rvd25sb2FkZWQiOjIuNTg1ODU4NTg1OCwicGVyY2VudF9kb3dubG9hZGVkIjowLjU4Mjc0NzczN30=",
+        "approximateArrivalTimestamp": 1487703700.299
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000005:49558266616753302169815546155894738867705645161305342035",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::561178107736:role/lambda_kinesis_execution",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:561178107736:stream/dovetail-metrics-production-6s"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "uh84huoedu74d43hu9o8eidbk8o9e74d",
+        "sequenceNumber": "59558266616753302169815546155894738867705645161305342034",
+        "data": "eyJ0eXBlIjoic2VnbWVudGJ5dGVzIiwidGltZXN0YW1wIjoxNTM5Mjg3NTI3LCJyZXF1ZXN0X3V1aWQiOiJyZXEtdXVpZCIsInNlZ21lbnRfaW5kZXgiOjQsImJ5dGVzX2Rvd25sb2FkZWQiOjEwNDgyMCwic2Vjb25kc19kb3dubG9hZGVkIjoyLjU4NTg1ODU4NTgsInBlcmNlbnRfZG93bmxvYWRlZCI6MC41ODI3NDc3Mzd9",
+        "approximateArrivalTimestamp": 1487703700.299
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000005:49558266616753302169815546155894738867705645161305342035",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::561178107736:role/lambda_kinesis_execution",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:561178107736:stream/dovetail-metrics-production-6s"
     }
   ]
 }

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -78,5 +78,22 @@
     "isDuplicate": false,
     "cause": null,
     "impressionUrl": "http://www.foo.bar/ping4"
+  },
+  {
+    "type": "bytes",
+    "timestamp": 1539287413617,
+    "request_uuid": "req-uuid",
+    "bytes_downloaded": 104820,
+    "seconds_downloaded": 2.5858585858,
+    "percent_downloaded": 0.582747737
+  },
+  {
+    "type": "segmentbytes",
+    "timestamp": 1539287527,
+    "request_uuid": "req-uuid",
+    "segment_index": 4,
+    "bytes_downloaded": 104820,
+    "seconds_downloaded": 2.5858585858,
+    "percent_downloaded": 0.582747737
   }
 ]


### PR DESCRIPTION
Should deploy before PRX/dovetail-counts-lambda#4

Finishing up PRX/analytics-ingest-lambda#24

- [x] Recognize new record `type`s coming from the counts lambda
- [x] Stream inserts into the 2 new bigquery `dt_download_bytes` and `dt_impression_bytes` tables