### PR TITLE
Debug pingback timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ exports.handler = (event, context, callback) => {
           callback(null, `Failsafe exit`);
           process.exit(0);
         }
-      }, 3000);
+      }, 25000);
     }
 
     // run inserts in parallel

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -80,12 +80,20 @@ module.exports.BigqueryInputs = class BigqueryInputs extends Inputs {
 }
 module.exports.PingbackInputs = class PingbackInputs extends Inputs {
   constructor(records) {
-    super(
-      records,
-      new Pingbacks(records),
-      new LegacyAdzerkImpressions(records),
-      new LegacyAdzerkPingbacks(records)
-    );
+    if (process.env.NO_3RD_PARTY_PINGBACKS) {
+      super(
+        records,
+        new Pingbacks(records),
+        new LegacyAdzerkImpressions(records)
+      );
+    } else {
+      super(
+        records,
+        new Pingbacks(records),
+        new LegacyAdzerkImpressions(records),
+        new LegacyAdzerkPingbacks(records)
+      );
+    }
   }
 }
 module.exports.RedisInputs = class RedisInputs extends Inputs {

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -29,7 +29,15 @@ exports.ping = (pingUrl, inputData, timeout, timeoutWait) => {
       port: parsed.port,
       headers: exports.parseHeaders(inputData)
     };
-    pinger.get(opts, resolve, reject);
+
+    let failsafe = setTimeout(function() {
+      reject(new Error(`HTTP timeout failsafe ${pingUrl}`));
+    }, pinger.timeout + 1000);
+
+    pinger.get(opts,
+      val => { clearTimeout(failsafe); resolve(val); },
+      val => { clearTimeout(failsafe); reject(val); }
+    );
   });
 }
 

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -24,7 +24,7 @@ exports.ping = (pingUrl, inputData, timeout, timeoutWait) => {
     let pinger = new HttpPing(timeout, timeoutWait);
     let opts = {
       url: pingUrl,
-      host: parsed.host,
+      host: parsed.hostname,
       path: parsed.path,
       port: parsed.port,
       headers: exports.parseHeaders(inputData)


### PR DESCRIPTION
In normal execution, the pingbacks should reject with an error after (A) 5 seconds or (B) 3x 500-ish errors.  And those errors are immediately caught/logged, so that the `Promise.all` of all pingbacks succeeds no matter what.

For some reason we've been hitting the 30 second timeout.  This:

- [x] Adds an extra failsafe timeout in `pingurl.js`, to reject with an error 1 second after the normal `http.get().setTimeout()`.  (In case that isn't working for whatever reason).
- [x] Adds an extra global timeout in `index.js`, to log the input records that failed after 25 seconds.  And optionally force exit.
- [x] Add an ENV to turn off 3rd party pingbacks more easily/quickly.