### PR TITLE
Blacklist doubleverify

### DIFF
--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -20,6 +20,9 @@ exports.ping = (pingUrl, inputData, timeout, timeoutWait) => {
     if (!parsed.host) {
       return reject(new Error(`Invalid ping url: ${pingUrl}`));
     }
+    if (parsed.hostname === 'tps.doubleverify.com') {
+      return reject(new Error(`tps.doubleverify.com is not our friend`));
+    }
 
     let pinger = new HttpPing(timeout, timeoutWait);
     let opts = {


### PR DESCRIPTION
Host `tps.doubleverify.com` often redirects to `ul1.dvtps.com`, which hangs forever.  And for some reason the http error/timeout handlers aren't catching it.