### PR TITLE
No duplicate bytes records

### DIFF
--- a/lib/inputs/ante-bytes.js
+++ b/lib/inputs/ante-bytes.js
@@ -26,9 +26,22 @@ module.exports = class AnteBytes {
 
   format(record) {
     const formatted = JSON.parse(JSON.stringify(record));
+
+    // id used as ddb key - remove redundant keys
     formatted.id = `${record.listenerSession}.${record.digest}`;
     delete formatted.listenerSession;
     delete formatted.digest;
+
+    // duplicates/reasons deprecated for byte downloads
+    if (formatted.download) {
+      delete formatted.download.isDuplicate;
+      delete formatted.download.reason;
+    }
+    (formatted.impressions || []).forEach(i => {
+      delete i.isDuplicate;
+      delete i.reason;
+    });
+
     return formatted;
   }
 

--- a/lib/inputs/byte-downloads.js
+++ b/lib/inputs/byte-downloads.js
@@ -55,6 +55,16 @@ module.exports = class ByteDownloads {
       rec.download = this._downloadKeys[lsd] ? rec.download : null;
       rec.impressions = (rec.impressions || []).filter(i => this._impressionKeys[`${lsd}.${i.segment}`]);
 
+      // duplicates/reasons deprecated for byte downloads
+      if (rec.download) {
+        delete rec.download.isDuplicate;
+        delete rec.download.reason;
+      }
+      rec.impressions.forEach(i => {
+        delete i.isDuplicate;
+        delete i.reason;
+      });
+
       // set record type so DovetailDownloads/Impressions will pick it up
       if (rec.type === 'antebytes') {
         rec.type = 'postbytes';

--- a/test/inputs-ante-bytes-test.js
+++ b/test/inputs-ante-bytes-test.js
@@ -25,6 +25,25 @@ describe('ante-bytes', () => {
     expect(formatted).to.eql({id: 'ls1.digest1', something: 'else'});
   });
 
+  it('removes duplicate flags', () => {
+    const bytes = new AnteBytes();
+    const formatted = bytes.format({
+      listenerSession: 'ls1',
+      digest: 'digest1',
+      download: {isDuplicate: true, reason: 'whatever', something: 'else'},
+      impressions: [
+        {segment: 0, isDuplicate: true, reason: 'anything'},
+        {segment: 2, isDuplicate: true},
+        {segment: 4, isDuplicate: false, reason: null},
+      ]
+    });
+    expect(formatted).to.eql({
+      id: 'ls1.digest1',
+      download: {something: 'else'},
+      impressions: [{segment: 0}, {segment: 2}, {segment: 4}]
+    });
+  });
+
   it('inserts nothing', () => {
     return new AnteBytes().insert().then(result => {
       expect(result.length).to.equal(0);


### PR DESCRIPTION
Belt and suspenders:

- [x] Remove `isDuplicate` / `reason` from incoming antebytes records
- [x] Also remove from outgoing postbytes records