### PR TITLE
Calculate listener sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ template.  Valid parameters are:
 | `ip`              | Request ip address |
 | `listener`        | Unique string for this "listener" |
 | `listenerepisode` | Unique string for "listener + url" |
-| `listenersession` | Unique string for "listener + url + UTCDate" |
 | `podcast`         | Feeder podcast id |
 | `randomstr`       | Random string |
 | `randomint`       | Random integer |

--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -58,11 +58,12 @@ module.exports = class DovetailDownloads {
 
   async format(record) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
+    const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
     const lookups = [lookip.look(record.remoteIp), lookagent.look(record.remoteAgent)];
     const [geo, agent] = await Promise.all(lookups);
 
     return {
-      insertId: `${record.listenerEpisode}/${epoch}`,
+      insertId: `${listenerSession}/${epoch}`,
       json: {
         timestamp:          epoch,
         request_uuid:       record.requestUuid || uuidv4(),
@@ -79,7 +80,7 @@ module.exports = class DovetailDownloads {
         // listener data
         listener_id:        record.listenerId,
         listener_episode:   record.listenerEpisode,
-        listener_session:   record.listenerSession,
+        listener_session:   listenerSession,
         // request data
         remote_referrer:    record.remoteReferrer,
         remote_agent:       record.remoteAgent,

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -58,15 +58,16 @@ module.exports = class DovetailImpressions {
 
   format(record, imp) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
+    const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
     return {
-      insertId: this.md5InsertId(`${record.listenerSession}-${epoch}`, imp),
+      insertId: this.md5InsertId(`${listenerSession}/${epoch}`, imp),
       json: {
         timestamp:        epoch,
         request_uuid:     record.requestUuid || uuidv4(),
         feeder_podcast:   record.feederPodcast,
         feeder_episode:   record.feederEpisode,
         digest:           record.digest,
-        listener_session: record.listenerSession,
+        listener_session: listenerSession,
         is_confirmed:     !!record.confirmed,
         is_bytes:         this.isBytes(record),
         segment:          imp.segment,

--- a/lib/timestamp.js
+++ b/lib/timestamp.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+
 // in the year 2000. in the year 2000.
 const THRESHOLD = 946684800000;
 
@@ -39,4 +41,12 @@ exports.toDateString = (timestamp) => {
 exports.toISOExtendedZ = (timestamp) => {
   let iso = new Date(exports.toEpochSeconds(timestamp) * 1000).toISOString();
   return iso.replace(/\.000Z$/, 'Z');
+}
+
+/**
+ * Calculate a digest of any string and a UTC day
+ */
+exports.toDigest = (str, timestamp) => {
+  const data = str + exports.toDateString(timestamp);
+  return crypto.createHash('md5').update(data).digest('hex');
 }

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -53,7 +53,6 @@ const TPL_PARAMS = {
   ip:              'remoteIp',
   listener:        'listenerId',
   listenerepisode: 'listenerEpisode',
-  listenersession: 'listenerSession',
   podcast:         'feederPodcast',
   randomstr:       'timestamp',
   randomint:       'timestamp',

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -81,7 +81,7 @@ describe('handler', () => {
     expect(inserted).to.have.keys('dt_downloads', 'dt_downloads_preview', 'dt_impressions');
 
     expect(inserted['dt_downloads'].length).to.equal(1);
-    expect(inserted['dt_downloads'][0].insertId).to.equal('listener-episode-1/1487703699');
+    expect(inserted['dt_downloads'][0].insertId).to.match(/^\w+\/1487703699$/);
     let downloadJson = inserted['dt_downloads'][0].json;
     expect(downloadJson.timestamp).to.equal(1487703699);
     expect(downloadJson.request_uuid).to.equal('req-uuid');
@@ -89,7 +89,7 @@ describe('handler', () => {
     expect(downloadJson.feeder_episode).to.equal('1234-5678');
     expect(downloadJson.listener_id).to.equal('some-listener-id');
     expect(downloadJson.listener_episode).to.equal('listener-episode-1');
-    expect(downloadJson.listener_session).to.equal('listener-session-1');
+    expect(downloadJson.listener_session.length).to.be.above(10);
     expect(downloadJson.is_confirmed).to.equal(false);
     expect(downloadJson.is_bytes).to.equal(false);
     expect(downloadJson.digest).to.equal('the-digest');
@@ -121,7 +121,7 @@ describe('handler', () => {
     expect(impressionJson.request_uuid).to.equal('req-uuid');
     expect(impressionJson.feeder_podcast).to.equal(1234);
     expect(impressionJson.feeder_episode).to.equal('1234-5678');
-    expect(impressionJson.listener_session).to.equal('listener-session-1');
+    expect(impressionJson.listener_session).to.equal(downloadJson.listener_session);
     expect(impressionJson.digest).to.equal('the-digest');
     expect(impressionJson.segment).to.equal(0);
     expect(impressionJson.is_confirmed).to.equal(false);
@@ -148,7 +148,8 @@ describe('handler', () => {
     expect(impressionJson.cause).to.equal(null);
 
     let previewJson = inserted['dt_downloads_preview'][0].json;
-    expect(previewJson.listener_session).to.equal('listener-session-6');
+    expect(previewJson.listener_session.length).to.be.above(10);
+    expect(previewJson.listener_session).not.to.equal(downloadJson.listener_session);
     expect(previewJson.feeder_podcast).to.equal(1234);
     expect(previewJson.feeder_episode).to.equal('1234-5678');
     expect(previewJson.is_bytes).to.equal(true);

--- a/test/inputs-dovetail-downloads-test.js
+++ b/test/inputs-dovetail-downloads-test.js
@@ -40,7 +40,7 @@ describe('dovetail-downloads', () => {
       listenerEpisode: 'something'
     });
     expect(record).to.have.keys('insertId', 'json');
-    expect(record.insertId).to.equal('something/1490827132');
+    expect(record.insertId).to.match(/^\w+\/1490827132$/);
     expect(record.json).to.have.keys(
       'timestamp',
       'request_uuid',

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -33,7 +33,7 @@ describe('dovetail-impressions', () => {
   });
 
   it('formats table inserts', () => {
-    const rec = {type: 'combined', timestamp: 1490827132999, listenerSession: 'something'};
+    const rec = {type: 'combined', timestamp: 1490827132999, listenerEpisode: 'something'};
 
     const format1 = impression.format(rec, {adId: 1, isDuplicate: true});
     expect(format1).to.have.keys('insertId', 'json');
@@ -46,21 +46,21 @@ describe('dovetail-impressions', () => {
       'is_duplicate', 'cause'
     );
     expect(format1.json.timestamp).to.equal(1490827132);
-    expect(format1.json.listener_session).to.equal('something');
+    expect(format1.json.listener_session.length).to.be.above(10);
     expect(format1.json.is_duplicate).to.equal(true);
 
     const format2 = impression.format(rec, {adId: 2, isDuplicate: false});
     expect(format2.json.timestamp).to.equal(1490827132);
-    expect(format2.json.listener_session).to.equal('something');
+    expect(format2.json.listener_session).to.equal(format1.json.listener_session);
     expect(format2.json.is_duplicate).to.equal(false);
     expect(format2.insertId).not.to.equal(format1.insertId);
   });
 
   it('creates unique insert ids for ads', () => {
-    const r1 = impression.format({listenerSession: 'req1'}, {adId: 1});
-    const r2 = impression.format({listenerSession: 'req1'}, {adId: 1});
-    const r3 = impression.format({listenerSession: 'req1'}, {adId: 2});
-    const r4 = impression.format({listenerSession: 'req2'}, {adId: 1});
+    const r1 = impression.format({listenerEpisode: 'req1'}, {adId: 1});
+    const r2 = impression.format({listenerEpisode: 'req1'}, {adId: 1});
+    const r3 = impression.format({listenerEpisode: 'req1'}, {adId: 2});
+    const r4 = impression.format({listenerEpisode: 'req2'}, {adId: 1});
     expect(r1.insertId).to.equal(r2.insertId);
     expect(r1.insertId).not.to.equal(r3.insertId);
     expect(r1.insertId).not.to.equal(r4.insertId);
@@ -81,33 +81,33 @@ describe('dovetail-impressions', () => {
     let impression2 = new DovetailImpressions([
       {type: 'impression', requestUuid: 'the-uuid1', timestamp: 1490827132999},
       {type: 'download', requestUuid: 'the-uuid2', timestamp: 1490827132999},
-      {type: 'combined', listenerSession: 'listen1', timestamp: 1490837132, impressions: []},
-      {type: 'combined', listenerSession: 'listen2', timestamp: 1490827132999, impressions: [{adId: 1}, {adId: 2}]},
-      {type: 'combined', listenerSession: 'listen3', timestamp: 1490837132, impressions: [{isDuplicate: true, adId: 3}]},
-      {type: 'postbytespreview', listenerSession: 'listen4', timestamp: 1490837132, impressions: [{adId: 4}]},
-      {type: 'postbytes', listenerSession: 'listen5', timestamp: 1490827132999, impressions: [{adId: 5}]}
+      {type: 'combined', listenerEpisode: 'listen1', timestamp: 1490837132, impressions: []},
+      {type: 'combined', listenerEpisode: 'listen2', timestamp: 1490827132999, impressions: [{adId: 1}, {adId: 2}]},
+      {type: 'combined', listenerEpisode: 'listen3', timestamp: 1490837132, impressions: [{isDuplicate: true, adId: 3}]},
+      {type: 'postbytespreview', listenerEpisode: 'listen4', timestamp: 1490837132, impressions: [{adId: 4}]},
+      {type: 'postbytes', listenerEpisode: 'listen5', timestamp: 1490827132999, impressions: [{adId: 5}]}
     ]);
     return impression2.insert().then(result => {
       expect(result.length).to.equal(2);
 
       expect(result[0].dest).to.equal('dt_impressions');
       expect(result[0].count).to.equal(4);
-      expect(inserts['dt_impressions'][0].json.listener_session).to.equal('listen2');
+      expect(inserts['dt_impressions'][0].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][0].json.ad_id).to.equal(1);
       expect(inserts['dt_impressions'][0].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][1].json.listener_session).to.equal('listen2');
+      expect(inserts['dt_impressions'][1].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][1].json.ad_id).to.equal(2);
       expect(inserts['dt_impressions'][1].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][2].json.listener_session).to.equal('listen3');
+      expect(inserts['dt_impressions'][2].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][2].json.ad_id).to.equal(3);
       expect(inserts['dt_impressions'][2].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][3].json.listener_session).to.equal('listen5');
+      expect(inserts['dt_impressions'][3].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][3].json.ad_id).to.equal(5);
       expect(inserts['dt_impressions'][3].json.is_bytes).to.equal(true);
 
       expect(result[1].dest).to.equal('dt_impressions_preview');
       expect(result[1].count).to.equal(1);
-      expect(inserts['dt_impressions_preview'][0].json.listener_session).to.equal('listen4');
+      expect(inserts['dt_impressions_preview'][0].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions_preview'][0].json.ad_id).to.equal(4);
       expect(inserts['dt_impressions_preview'][0].json.is_bytes).to.equal(true);
     });

--- a/test/timestamp-test.js
+++ b/test/timestamp-test.js
@@ -46,4 +46,16 @@ describe('timestamp', () => {
     expect(timestamp.toISOExtendedZ(1490827132010)).to.equal('2017-03-29T22:38:52Z');
   });
 
+  it('creates digests based on the utc-day of a timestamp', () => {
+    const d1 = timestamp.toDigest('any-str', 1490827132000);
+    const d2 = timestamp.toDigest('any-str2', 1490827132000);
+    const d3 = timestamp.toDigest('any-str', 1490827132999);
+    const d4 = timestamp.toDigest('any-str', 1490831999999);
+    const d5 = timestamp.toDigest('any-str', 1490832000000);
+    expect(d1).not.to.equal(d2);
+    expect(d1).to.equal(d3);
+    expect(d1).to.equal(d4);
+    expect(d1).not.to.equal(d5);
+  });
+
 });

--- a/test/urlutil-test.js
+++ b/test/urlutil-test.js
@@ -18,7 +18,6 @@ describe('urlutil', () => {
       timestamp: 1507234920,
       listenerId: 'listener-id',
       listenerEpisode: 'listener-episode',
-      listenerSession: 'listener-session',
       adId: 9,
       campaignId: 8,
       creativeId: 7,
@@ -30,7 +29,7 @@ describe('urlutil', () => {
 
   it('expands non-transformed params', () => {
     let nonTransforms = ['ad', 'agent', 'campaign', 'creative', 'episode',
-      'flight', 'listener', 'listenerepisode', 'listenersession', 'podcast',
+      'flight', 'listener', 'listenerepisode', 'podcast',
       'referer'];
     let url = urlutil.expand(`http://foo.bar/{?${nonTransforms.join(',')}}`, TEST_IMPRESSION());
     let params = URI(url).query(true);
@@ -43,7 +42,6 @@ describe('urlutil', () => {
     expect(params.flight).to.equal('6');
     expect(params.listener).to.equal('listener-id');
     expect(params.listenerepisode).to.equal('listener-episode');
-    expect(params.listenersession).to.equal('listener-session');
     expect(params.podcast).to.equal('1234');
     expect(params.referer).to.equal('http://www.prx.org/');
   });


### PR DESCRIPTION
Dovetail will no longer be sending `listenerSession`s over kinesis.  Calculate them ourselves - using a sha of the `listenerEpisode + utcDay`.  (Each UTC day, you get a new session for the same episode).

Longer term, not sure if we want to keep listenerSessions around.  But for now, this should work!