### PR TITLE
Pixel trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Records with the special type `postbytespreview`  will also be inserted into a
 "preview" BigQuery table, for running both legacy and IAB 2.0 compliant inserts
 in parallel for a program.
 
+Records with type `pixel` will also be inserted into BigQuery, under the dataset/table
+indicated in the `record.destination`. Since these destination tables are less
+controlled, errors on insert (missing table, bad schema, etc) will be logged and
+ignored.
+
 ## Pingbacks
 
 Records with type `combined`/`postbytes` and a special `impression[].pings` array will be pinged via
@@ -134,7 +139,7 @@ a `DDB_ROLE` that the lambda should assume while doing gets/writes.
 
 The 4 lambdas functions are deployed via a Cloudformation stack in the [Infrastructure repo](https://github.com/PRX/Infrastructure/blob/master/stacks/analytics-ingest-lambda.yml):
 
- - `AnalyticsBigqueryLambda` - insert downloads/impressions into BigQuery
+ - `AnalyticsBigqueryLambda` - insert downloads/impressions/pixels into BigQuery
  - `AnalyticsPingbacksLambda` - ping Adzerk impressions and 3rd-party pingbacks
  - `AnalyticsRedisLambda` - realtime Redis increments
  - `AnalyticsDynamodbLambda` - temporary store for IAB compliant downloads

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -1,83 +1,63 @@
-'use strict';
-
-const {BigQuery} = require('@google-cloud/bigquery');
-const decrypt = require('./decrypt');
-let _cachedDataset;
-let _bqKey;
+const {BigQuery} = require('@google-cloud/bigquery')
+const decrypt = require('./decrypt')
 
 /**
- * Memoize the dataset we're using for this env
+ * Streaming inserts
  */
-exports.dataset = (forceRefresh) => {
-  if (forceRefresh || !_cachedDataset) {
-    let key = process.env.BQ_PRIVATE_KEY || '';
-    let keyPromise;
-
-    // the key may be encrypted out in aws - note that decrypted keys will come
-    // out a bit funky, with their newlines encoded
-    if (_bqKey && !forceRefresh) {
-      keyPromise = Promise.resolve(_bqKey);
-    } else if (key.match(/^\"{0,1}-----/)) {
-      keyPromise = Promise.resolve(key.replace(/\\n/g, '\n').replace(/\"/, ''));
-    } else {
-      keyPromise = decrypt.decryptAws(key).then(decrypted => {
-        return decrypted.replace(/\\n/g, '\n');
-      });
-    }
-
-    return keyPromise.then(key => {
-      // save the key so we don't have to decrypt every time
-      _bqKey = key;
-
-      const bigquery = new BigQuery({
-        projectId: process.env.BQ_PROJECT_ID,
-        credentials: {
-          client_email: process.env.BQ_CLIENT_EMAIL,
-          private_key: key
-        }
-      });
-      const dataset = bigquery.dataset(process.env.BQ_DATASET);
-      return _cachedDataset = dataset;
-    });
-  } else {
-    return Promise.resolve(_cachedDataset);
-  }
-};
-
-/**
- * Streaming inserts (returns promise)
- */
-exports.insert = (table, rows, retries) => {
-  if (retries === undefined) {
-    retries = 2;
-  }
+exports.insert = async (dataset, table, rows, retries = 2) => {
   if (rows.length === 0) {
-    return Promise.resolve(0);
+    return 0
   }
-  return exports.dataset().then(dataset => {
-    return dataset.table(table).insert(rows, {raw: true});
-  }).then(
-    res => {
-      return rows.length;
-    },
-    err => {
-      if (err.message.match(/client_email/)) {
-        throw new Error('You forgot to set BQ_CLIENT_EMAIL');
-      } else if (err.message.match(/private_key/)) {
-        throw new Error('You forgot to set BQ_PRIVATE_KEY');
-      } else if (err.message.match(/PEM_read_bio/)) {
-        throw new Error('You have a poorly formatted BQ_PRIVATE_KEY');
-      } else if (err.message.match(/invalid_client/)) {
-        throw new Error('Invalid BQ_CLIENT_EMAIL and/or BQ_PRIVATE_KEY');
-      } else if (err.message.match(/without a project ID/)) {
-        throw new Error('You forgot to set BQ_PROJECT_ID');
-      } else if (err.message.match(/Not Found/)) {
-        throw new Error(`Could not find table: ${err.response.req.path}`)
-      } else if (retries > 0) {
-        return exports.insert(table, rows, retries - 1);
-      } else {
-        throw err;
-      }
+  try {
+    const client = await exports.client()
+    const result = await client.dataset(dataset).table(table).insert(rows, {raw: true})
+    console.log('result!', result)
+    return rows.length
+  } catch (err) {
+    if (err.message.match(/client_email/)) {
+      throw new Error('You forgot to set BQ_CLIENT_EMAIL')
+    } else if (err.message.match(/private_key/)) {
+      throw new Error('You forgot to set BQ_PRIVATE_KEY')
+    } else if (err.message.match(/PEM_read_bio/)) {
+      throw new Error('You have a poorly formatted BQ_PRIVATE_KEY')
+    } else if (err.message.match(/invalid_client/)) {
+      throw new Error('Invalid BQ_CLIENT_EMAIL and/or BQ_PRIVATE_KEY')
+    } else if (err.message.match(/without a project ID/)) {
+      throw new Error('You forgot to set BQ_PROJECT_ID')
+    } else if (err.message.match(/Not Found/)) {
+      throw new Error(`Could not find table: ${err.response.req.path}`)
+    } else if (retries > 0) {
+      return exports.insert(dataset, table, rows, retries - 1)
+    } else {
+      throw err
     }
-  );
-};
+  }
+}
+
+/**
+ * Insert with retries
+ */
+exports.client = async () => {
+  const projectId = process.env.BQ_PROJECT_ID
+  const client_email = process.env.BQ_CLIENT_EMAIL
+  const private_key = await exports.key()
+  return new BigQuery({projectId, credentials: {client_email, private_key}})
+}
+
+/**
+ * Optionally decrypt the key, and cache the result
+ */
+const _key = null
+exports.key = async (force = false) => {
+  if (_key && !force) {
+    return _key
+  } else {
+    const key = process.env.BQ_PRIVATE_KEY || ''
+    if (key.match(/^"{0,1}-----/)) {
+      return key.replace(/\\n/g, '\n').replace(/"/, '')
+    } else {
+      const decrypted = await decrypt.decryptAws(key)
+      return decrypted.replace(/\\n/g, '\n')
+    }
+  }
+}

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -11,7 +11,6 @@ exports.insert = async (dataset, table, rows, retries = 2) => {
   try {
     const client = await exports.client()
     const result = await client.dataset(dataset).table(table).insert(rows, {raw: true})
-    console.log('result!', result)
     return rows.length
   } catch (err) {
     if (err.message.match(/client_email/)) {

--- a/lib/bigquery.js
+++ b/lib/bigquery.js
@@ -46,17 +46,17 @@ exports.client = async () => {
 /**
  * Optionally decrypt the key, and cache the result
  */
-const _key = null
+let _key = null
 exports.key = async (force = false) => {
   if (_key && !force) {
     return _key
   } else {
     const key = process.env.BQ_PRIVATE_KEY || ''
     if (key.match(/^"{0,1}-----/)) {
-      return key.replace(/\\n/g, '\n').replace(/"/, '')
+      return _key = key.replace(/\\n/g, '\n').replace(/"/, '')
     } else {
       const decrypted = await decrypt.decryptAws(key)
-      return decrypted.replace(/\\n/g, '\n')
+      return _key = decrypted.replace(/\\n/g, '\n')
     }
   }
 }

--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -50,8 +50,9 @@ module.exports = class DovetailDownloads {
     const tableNames = Object.keys(formatted);
 
     // insert in parallel
+    const ds = process.env.BQ_DATASET || '';
     return await Promise.all(tableNames.map(async (tbl) => {
-      const num = await bigquery.insert(tbl, formatted[tbl]);
+      const num = await bigquery.insert(ds, tbl, formatted[tbl]);
       return {count: num, dest: tbl};
     }));
   }

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -50,8 +50,9 @@ module.exports = class DovetailImpressions {
     const tableNames = Object.keys(formatted);
 
     // insert in parallel
+    const ds = process.env.BQ_DATASET || '';
     return await Promise.all(tableNames.map(async (tbl) => {
-      const num = await bigquery.insert(tbl, formatted[tbl]);
+      const num = await bigquery.insert(ds, tbl, formatted[tbl]);
       return {count: num, dest: tbl};
     }));
   }

--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -6,6 +6,7 @@ const ByteDownloads = require('./byte-downloads');
 const DovetailDownloads = require('./dovetail-downloads');
 const DovetailImpressions = require('./dovetail-impressions');
 const Pingbacks = require('./pingbacks');
+const PixelTrackers = require('./pixel-trackers');
 const RedisIncrements = require('./redis-increments');
 
 /**
@@ -26,6 +27,7 @@ class Inputs {
       new DovetailDownloads(),
       new DovetailImpressions(),
       new Pingbacks(),
+      new PixelTrackers(),
       new RedisIncrements(),
     ];
     records.forEach(r => {
@@ -59,7 +61,12 @@ class Inputs {
  */
 module.exports.BigqueryInputs = class BigqueryInputs extends Inputs {
   constructor(records) {
-    super(records, new DovetailDownloads(records), new DovetailImpressions(records));
+    super(
+      records,
+      new DovetailDownloads(records),
+      new DovetailImpressions(records),
+      new PixelTrackers(records)
+    );
   }
 };
 module.exports.DynamoInputs = class DynamoInputs extends Inputs {

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -34,9 +34,24 @@ module.exports = class PixelTrackers {
 
     // insert in parallel
     return await Promise.all(Object.keys(grouped).map(async (datasetTable) => {
-      const [ds, tbl] = datasetTable.split('.')
-      const num = await bigquery.insert(ds, tbl, grouped[datasetTable])
-      return {count: num, dest: datasetTable}
+      try {
+        const [ds, tbl] = datasetTable.split('.')
+        const num = await bigquery.insert(ds, tbl, grouped[datasetTable])
+        return {count: num, dest: datasetTable}
+      } catch (err) {
+        if (err.code === 404) {
+          logger.error(`Table not found: ${datasetTable}`)
+          return {count: 0, dest: datasetTable}
+        } else {
+          const insertErrors = logger.combineErrors(err)
+          if (insertErrors) {
+            logger.error(`Insert errors on ${datasetTable}: ${insertErrors}`)
+            return {count: 0, dest: datasetTable}
+          } else {
+            throw err
+          }
+        }
+      }
     }))
   }
 

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -79,8 +79,12 @@ module.exports = class PixelTrackers {
   }
 
   userId(rec) {
-    const parts = [rec.remoteAgent, rec.remoteIp, rec.remoteReferrer].join('-')
-    return crypto.createHash('md5').update(parts).digest('hex')
+    if (rec.userId) {
+      return rec.userId
+    } else {
+      const parts = [rec.remoteAgent, rec.remoteIp, rec.remoteReferrer].join('-')
+      return crypto.createHash('md5').update(parts).digest('hex')
+    }
   }
 
   insertId(epoch, userId, key, canonical) {

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -1,0 +1,88 @@
+const crypto = require('crypto')
+const logger = require('../logger')
+const timestamp = require('../timestamp')
+const lookip = require('../lookip')
+const bigquery = require('../bigquery')
+
+/**
+ * Pixel.prx.org trackers
+ */
+module.exports = class PixelTrackers {
+
+  constructor(records) {
+    this._records = (records || []).filter(r => this.check(r))
+  }
+
+  check(record) {
+    return record.type === 'pixel'
+  }
+
+  async insert() {
+    if (this._records.length === 0) {
+      return []
+    }
+
+    // format records and organize by dataset + table
+    const formatted = await Promise.all(this._records.map(r => this.format(r)))
+    const grouped = this._records.reduce((acc, rec, idx) => {
+      const dest = this.destination(rec)
+      if (dest) {
+        (acc[dest] = acc[dest] || []).push(formatted[idx])
+      }
+      return acc
+    }, {})
+
+    // insert in parallel
+    return await Promise.all(Object.keys(grouped).map(async (datasetTable) => {
+      const [ds, tbl] = datasetTable.split('.')
+      const num = await bigquery.insert(ds, tbl, grouped[datasetTable])
+      return {count: num, dest: datasetTable}
+    }))
+  }
+
+  async format(record) {
+    const epoch = timestamp.toEpochSeconds(record.timestamp || 0)
+    const userId = this.userId(record)
+    const geo = await lookip.look(record.remoteIp)
+    return {
+      insertId: this.insertId(epoch, userId, record.key, record.canonical),
+      json: {
+        timestamp:          epoch,
+        user_id:            userId,
+        key:                record.key,
+        canonical:          record.canonical,
+        remote_agent:       record.remoteAgent,
+        remote_referrer:    record.remoteReferrer,
+        remote_ip:          geo.masked,
+        city_geoname_id:    geo.city,
+        country_geoname_id: geo.country,
+        postal_code:        geo.postal,
+        latitude:           geo.latitude,
+        longitude:          geo.longitude
+      }
+    }
+  }
+
+  userId(rec) {
+    const parts = [rec.remoteAgent, rec.remoteIp, rec.remoteReferrer].join('-')
+    return crypto.createHash('md5').update(parts).digest('hex')
+  }
+
+  insertId(epoch, userId, key, canonical) {
+    const parts = [epoch, userId, key, canonical].join('-')
+    return crypto.createHash('md5').update(parts).digest('hex')
+  }
+
+  destination(rec) {
+    const parts = (rec.destination || '').split('.')
+    if (parts.length === 2 && parts[0] && parts[1]) {
+      return `${parts[0]}.${parts[1]}`
+    } else if (parts.length === 1 && parts[0] && process.env.BQ_DATASET) {
+      return `${process.env.BQ_DATASET}.${parts[0]}`
+    } else {
+      logger.error(`No destination in record: ${JSON.stringify(rec)}`)
+      return null
+    }
+  }
+
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -10,34 +10,31 @@ exports.error = msg => console.error('[ERROR]', msg);
  * Error decoding/logging (some bigquery errors are very nested)
  */
 exports.errors = err => {
-  let errs = [];
-  if (err.errors) {
-    errs = errs.concat(err.errors.map(e => decodeErrors(e)));
+  if (err.response && err.response.insertErrors) {
+    err.message = exports.combineErrors(err);
   } else if (err.reason && err.message) {
-    errs.push(new Error(`${err.reason} - ${err.message}`));
-  } else {
-    errs.push(err);
+    err.message = `${err.reason} - ${err.message}`;
   }
-  errs.forEach(e => exports.error(`${e}`));
-
-  // return a single error
-  if (errs.length === 1) {
-    return errs[0];
-  } else if (errs.length > 1) {
-    let msgs = errs.map(e => `${e}`).join(', ');
-    return new Error(`Multiple errors: ${msgs}`);
-  } else {
-    return null;
-  }
+  exports.error(`${err}`);
+  return err;
 }
 
-// decode these crazy nested err.errors.errors
-function decodeErrors(err) {
-  if (err.errors) {
-    return [].concat(err.errors.map(e => decodeErrors(e)));
-  } else if (err.reason && err.message) {
-    return new Error(`${err.reason} - ${err.message}`);
-  } else {
-    return err;
-  }
+/**
+ * Combine insert errors into single string
+ */
+exports.combineErrors = original => {
+  let msgs = [];
+  ((original.response || {}).insertErrors || []).forEach(err => {
+    if (err.errors && err.errors[0]) {
+      if (err.errors[0].location && err.errors[0].message) {
+        msgs.push(`${err.errors[0].location}: ${err.errors[0].message}`);
+      } else if (err.errors[0].message) {
+        msgs.push(err.errors[0].message);
+      } else if (err.errors[0].reason) {
+        msgs.push(err.errors[0].reason);
+      }
+    }
+  });
+  msgs = msgs.map(m => m.replace(/\.$/, ''));
+  return msgs.filter((m, idx) => msgs.indexOf(m) === idx).join(', ');
 }

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -59,13 +59,9 @@ describe('handler', () => {
 
   it('handles bigquery records', async () => {
     const inserted = {};
-    sinon.stub(bigquery, 'dataset').resolves({
-      table: tbl => {
-        return {insert: async (rows) => {
-          inserted[tbl] = rows;
-          return Promise.resolve(rows.length);
-        }};
-      }
+    sinon.stub(bigquery, 'insert').callsFake((ds, tbl, rows) => {
+      inserted[tbl] = rows;
+      return Promise.resolve(rows.length);
     });
 
     const result = await handler(event);

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -65,8 +65,8 @@ describe('handler', () => {
     });
 
     const result = await handler(event);
-    expect(result).to.match(/inserted 5/i);
-    expect(infos.length).to.equal(3);
+    expect(result).to.match(/inserted 6/i);
+    expect(infos.length).to.equal(4);
     expect(warns.length).to.equal(0);
     expect(errs.length).to.equal(0);
     expect(infos[0]).to.match(/1 rows into dt_downloads/);
@@ -74,7 +74,7 @@ describe('handler', () => {
     expect(infos[2]).to.match(/3 rows into dt_impressions/);
 
     // based on test-records
-    expect(inserted).to.have.keys('dt_downloads', 'dt_downloads_preview', 'dt_impressions');
+    expect(inserted).to.have.keys('dt_downloads', 'dt_downloads_preview', 'dt_impressions', 'pixels');
 
     expect(inserted['dt_downloads'].length).to.equal(1);
     expect(inserted['dt_downloads'][0].insertId).to.match(/^\w+\/1487703699$/);
@@ -151,6 +151,22 @@ describe('handler', () => {
     expect(previewJson.is_bytes).to.equal(true);
     expect(previewJson.is_duplicate).to.equal(false);
     expect(previewJson.cause).to.equal(null);
+
+    expect(inserted['pixels'].length).to.equal(1);
+    expect(inserted['pixels'][0].json).to.eql({
+      canonical: 'https://www.prx.org/url1',
+      city_geoname_id: null,
+      country_geoname_id: null,
+      key: 'key1',
+      latitude: null,
+      longitude: null,
+      postal_code: null,
+      remote_agent: 'some-user-agent',
+      remote_ip: '127.0.0.0',
+      remote_referrer: 'https://www.prx.org/technology/',
+      timestamp: 1490827132,
+      user_id: 'd24a63774631fde164fa2bc27e58db5e',
+    });
   });
 
   it('handles dynamodb records', async () => {

--- a/test/inputs-dovetail-downloads-test.js
+++ b/test/inputs-dovetail-downloads-test.js
@@ -82,7 +82,7 @@ describe('dovetail-downloads', () => {
 
   it('inserts download records', () => {
     let inserts = {};
-    sinon.stub(bigquery, 'insert').callsFake((tbl, rows) => {
+    sinon.stub(bigquery, 'insert').callsFake((ds, tbl, rows) => {
       inserts[tbl] = rows;
       return Promise.resolve(rows.length);
     });

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -74,7 +74,7 @@ describe('dovetail-impressions', () => {
 
   it('inserts impression records', () => {
     let inserts = {};
-    sinon.stub(bigquery, 'insert').callsFake((tbl, rows) => {
+    sinon.stub(bigquery, 'insert').callsFake((ds, tbl, rows) => {
       inserts[tbl] = rows;
       return Promise.resolve(rows.length);
     });

--- a/test/inputs-pixel-trackers-test.js
+++ b/test/inputs-pixel-trackers-test.js
@@ -1,0 +1,110 @@
+const support = require('./support')
+const bigquery = require('../lib/bigquery')
+const logger = require('../lib/logger')
+const PixelTrackers = require('../lib/inputs/pixel-trackers')
+
+describe('pixel-trackers', () => {
+
+  let pixel = new PixelTrackers()
+  const data = {
+    type: 'pixel',
+    timestamp: 1490827132999,
+    key: 'the-key',
+    canonical: 'the-canonical',
+    remoteAgent: 'the-user-agent',
+    remoteIp: '127.0.0.1',
+    remoteReferrer: 'the-referer',
+  }
+
+  it('recognizes pixel records', () => {
+    expect(pixel.check({})).to.be.false
+    expect(pixel.check({type: 'impression'})).to.be.false
+    expect(pixel.check({type: 'pixel'})).to.be.true
+  })
+
+  it('knows the destinations of records', () => {
+    expect(pixel.destination({destination: 'tablename'})).to.equal('foobar_dataset.tablename')
+    expect(pixel.destination({destination: 'foo.bar'})).to.equal('foo.bar')
+  })
+
+  it('logs bad destinations', () => {
+    sinon.stub(logger, 'error')
+
+    expect(pixel.destination({destination: ''})).to.be.null
+    expect(logger.error).to.have.callCount(1)
+    expect(logger.error.args[0][0]).to.match(/No destination in record:/)
+
+    expect(pixel.destination({destination: 'one.two.three'})).to.be.null
+    expect(logger.error).to.have.callCount(2)
+    expect(logger.error.args[1][0]).to.match(/No destination in record:/)
+  })
+
+  it('formats table inserts', async () => {
+    const record = await pixel.format(data)
+    expect(record).to.have.keys('insertId', 'json')
+    expect(record.insertId.length).to.be.above(10)
+    expect(record.json).to.eql({
+      timestamp: 1490827132,
+      user_id: pixel.userId(data),
+      key: 'the-key',
+      canonical: 'the-canonical',
+      remote_agent: 'the-user-agent',
+      remote_referrer: 'the-referer',
+      remote_ip: '127.0.0.0',
+      city_geoname_id: null,
+      country_geoname_id: null,
+      postal_code: null,
+      latitude: null,
+      longitude: null,
+    })
+  })
+
+  it('generates unique user ids', async () => {
+    const record1 = await pixel.format(data)
+    const record2 = await pixel.format({...data, key: 'other-key'})
+    const record3 = await pixel.format({...data, canonical: 'other-canonical'})
+    const record4 = await pixel.format({...data, remoteIp: '127.0.0.2'})
+    expect(record1.json.user_id).to.equal(record2.json.user_id)
+    expect(record1.json.user_id).to.equal(record3.json.user_id)
+    expect(record1.json.user_id).not.to.equal(record4.json.user_id)
+  })
+
+  it('generates unique insert ids', async () => {
+    const record1 = await pixel.format(data)
+    const record2 = await pixel.format({...data})
+    const record3 = await pixel.format({...data, key: 'other-key'})
+    const record4 = await pixel.format({...data, canonical: 'other-canonical'})
+    const record5 = await pixel.format({...data, timestamp: 123456789})
+    expect(record1.insertId).to.equal(record2.insertId)
+    expect(record1.insertId).not.to.equal(record3.insertId)
+    expect(record1.insertId).not.to.equal(record4.insertId)
+    expect(record1.insertId).not.to.equal(record5.insertId)
+  })
+
+  it('inserts nothing', async () => {
+    const result = await pixel.insert()
+    expect(result.length).to.equal(0)
+  })
+
+  it('inserts download records', async () => {
+    let inserts = {}
+    sinon.stub(bigquery, 'insert').callsFake(async (ds, tbl, rows) => {
+      inserts[`${ds}.${tbl}`] = rows
+      return rows.length
+    })
+
+    const pixel2 = new PixelTrackers([
+      {type: 'download', key: '1'},
+      {type: 'pixel', key: '2', destination: 'foo.bar'},
+      {type: 'pixel', key: '3', destination: 'bar'},
+      {type: 'pixel', key: '4', destination: 'foobar_dataset.bar'},
+      {type: 'pixel', key: '5', destination: 'bar'},
+      {type: 'pixel', key: '6', destination: 'foo.bar'},
+    ])
+    const results = await pixel2.insert()
+    expect(results.length).to.equal(2)
+    expect(results[0]).to.eql({count: 2, dest: 'foo.bar'})
+    expect(results[1]).to.eql({count: 3, dest: 'foobar_dataset.bar'})
+  })
+
+})

--- a/test/inputs-pixel-trackers-test.js
+++ b/test/inputs-pixel-trackers-test.js
@@ -14,6 +14,7 @@ describe('pixel-trackers', () => {
     remoteAgent: 'the-user-agent',
     remoteIp: '127.0.0.1',
     remoteReferrer: 'the-referer',
+    userId: 'the-user-id',
   }
 
   it('recognizes pixel records', () => {
@@ -45,7 +46,7 @@ describe('pixel-trackers', () => {
     expect(record.insertId.length).to.be.above(10)
     expect(record.json).to.eql({
       timestamp: 1490827132,
-      user_id: pixel.userId(data),
+      user_id: 'the-user-id',
       key: 'the-key',
       canonical: 'the-canonical',
       remote_agent: 'the-user-agent',
@@ -59,11 +60,11 @@ describe('pixel-trackers', () => {
     })
   })
 
-  it('generates unique user ids', async () => {
-    const record1 = await pixel.format(data)
-    const record2 = await pixel.format({...data, key: 'other-key'})
-    const record3 = await pixel.format({...data, canonical: 'other-canonical'})
-    const record4 = await pixel.format({...data, remoteIp: '127.0.0.2'})
+  it('generates unique user ids when not set', async () => {
+    const record1 = await pixel.format({...data, userId: undefined})
+    const record2 = await pixel.format({...data, userId: undefined, key: 'other-key'})
+    const record3 = await pixel.format({...data, userId: undefined, canonical: 'other-canonical'})
+    const record4 = await pixel.format({...data, userId: undefined, remoteIp: '127.0.0.2'})
     expect(record1.json.user_id).to.equal(record2.json.user_id)
     expect(record1.json.user_id).to.equal(record3.json.user_id)
     expect(record1.json.user_id).not.to.equal(record4.json.user_id)

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -30,14 +30,16 @@ describe('inputs', () => {
       {type: 'combined',     listenerId: 'd1', timestamp: 0, download: {}},
       {type: 'combined',     listenerId: 'i2', timestamp: 999999, impressions: [{}]},
       {type: 'segmentbytes', listenerId: 'b1', timestamp: 999999},
-      {type: 'bytes',        listenerId: 'b2', timestamp: 999999}
+      {type: 'bytes',        listenerId: 'b2', timestamp: 999999},
+      {type: 'pixel', destination: 'foo.bar', timestamp: 999999},
     ]);
     return inputs.insertAll().then(inserts => {
-      expect(inserts.length).to.equal(2);
-      expect(inserts.map(i => i.count)).to.eql([1, 2]);
+      expect(inserts.length).to.equal(3);
+      expect(inserts.map(i => i.count)).to.eql([1, 2, 1]);
       expect(inserts.map(i => i.dest).sort()).to.eql([
         'dt_downloads',
-        'dt_impressions'
+        'dt_impressions',
+        'foo.bar',
       ]);
     });
   });

--- a/test/inputs-test.js
+++ b/test/inputs-test.js
@@ -23,7 +23,7 @@ describe('inputs', () => {
 
   it('inserts all bigquery inputs', () => {
     sinon.stub(logger, 'info');
-    sinon.stub(bigquery, 'insert').callsFake((tbl, rows) => Promise.resolve(rows.length));
+    sinon.stub(bigquery, 'insert').callsFake((ds, tbl, rows) => Promise.resolve(rows.length));
     let inputs = new BigqueryInputs([
       {type: 'combined',     listenerId: 'i1', timestamp: 0, impressions: [{}]},
       {type: 'foobar',       listenerId: 'fb', timestamp: 0},

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -119,5 +119,15 @@
       "cause": null,
       "isDupliciate": false
     }
+  },
+  {
+    "type": "pixel",
+    "destination": "dataset2.pixels",
+    "timestamp": 1490827132999,
+    "key": "key1",
+    "canonical": "https://www.prx.org/url1",
+    "remoteAgent": "some-user-agent",
+    "remoteIp": "127.0.0.1",
+    "remoteReferrer": "https://www.prx.org/technology/"
   }
 ]

--- a/test/support/test-runner-records.json
+++ b/test/support/test-runner-records.json
@@ -176,5 +176,25 @@
     "remoteReferrer": "",
     "timestamp": 1487803699,
     "url": "/1234/1234-5678/filename.mp3?foo=bar"
+  },
+  {
+    "type": "pixel",
+    "destination": "pixels",
+    "timestamp": 1490827132999,
+    "key": "test-runner-records1",
+    "canonical": "https://www.prx.org/url1",
+    "remoteAgent": "some-user-agent",
+    "remoteIp": "50.21.204.248",
+    "remoteReferrer": "https://www.prx.org/technology/"
+  },
+  {
+    "type": "pixel",
+    "destination": "pixels",
+    "timestamp": 1490827132999,
+    "key": "test-runner-records1",
+    "canonical": "https://www.prx.org/url1",
+    "remoteAgent": "some-other-agent",
+    "remoteIp": "127.0.0.1",
+    "remoteReferrer": "https://www.prx.org/technology/"
   }
 ]

--- a/test/support/test-runner-records.json
+++ b/test/support/test-runner-records.json
@@ -185,7 +185,8 @@
     "canonical": "https://www.prx.org/url1",
     "remoteAgent": "some-user-agent",
     "remoteIp": "50.21.204.248",
-    "remoteReferrer": "https://www.prx.org/technology/"
+    "remoteReferrer": "https://www.prx.org/technology/",
+    "userId": "my-explicit-user-id"
   },
   {
     "type": "pixel",


### PR DESCRIPTION
For #38.

- Since pixel-hits are signed, can rely on the record `destination` to tell us which dataset/table to insert into.  But just in case those are wrong ... ignore missing-table/bad-schema errors, so we don't try them indefinitely.
- Lookup / obfuscate the `remote_ip` the same way we do for dovetail records
- Didn't do any user-agent lookup.  Will wait for some more definite requirements on that.