### PR TITLE
Mask pingback ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ template.  Valid parameters are:
 | `creative`        | Adzerk creative id |
 | `flight`          | Adzerk flight id |
 | `ip`              | Request ip address |
+| `ipmask`          | Masked ip, with the last octet changed to 0s |
 | `listener`        | Unique string for this "listener" |
 | `listenerepisode` | Unique string for "listener + url" |
 | `podcast`         | Feeder podcast id |

--- a/lib/lookip.js
+++ b/lib/lookip.js
@@ -25,8 +25,16 @@ function maxdb() {
  * Sanity check ip addresses
  */
 exports.clean = (ipString) => {
-  let parts = (ipString || '').split(',').map(s => s.trim());
-  return parts.filter(s => s && (ip.isV4Format(s) || ip.isV6Format(s)))[0];
+  return exports.cleanAll(ipString, false)[0];
+}
+exports.cleanAll = (xffString, join = true) => {
+  let parts = (xffString || '').split(',').map(s => s.trim());
+  let cleaned = parts.filter(s => s && (ip.isV4Format(s) || ip.isV6Format(s)));
+  if (join) {
+    return cleaned.join(', ') || undefined;
+  } else {
+    return cleaned;
+  }
 }
 
 /**
@@ -38,8 +46,13 @@ exports.mask = (cleanIpString) => {
   } else if (ip.isV6Format(cleanIpString)) {
     return ip.mask(cleanIpString, 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:0');
   } else {
-    return null;
+    return cleanIpString;
   }
+}
+exports.maskLeft = (cleanXffString) => {
+  const parts = (cleanXffString || '').split(', ');
+  parts[0] = exports.mask(parts[0]);
+  return parts.join(', ');
 }
 
 /**

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -6,6 +6,7 @@ followRedirects.maxRedirects = 10;
 const http = followRedirects.http;
 const https = followRedirects.https;
 const logger = require('./logger');
+const lookip = require('./lookip');
 
 const TIMEOUT_MS = 5000;
 const TIMEOUT_WAIT_MS = 1000;
@@ -57,7 +58,10 @@ exports.parseHeaders = (data) => {
     headers['User-Agent'] = data.remoteAgent;
   }
   if (data && data.remoteIp) {
-    headers['X-Forwarded-For'] = data.remoteIp;
+    const clean = lookip.cleanAll(data.remoteIp);
+    if (clean) {
+      headers['X-Forwarded-For'] = lookip.maskLeft(clean);
+    }
   }
   if (data && data.remoteReferrer) {
     headers['Referer'] = data.remoteReferrer;

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -51,6 +51,7 @@ const TPL_PARAMS = {
   episode:         'feederEpisode',
   flight:          'flightId',
   ip:              'remoteIp',
+  ipmask:          'remoteIp',
   listener:        'listenerId',
   listenerepisode: 'listenerEpisode',
   podcast:         'feederPodcast',
@@ -67,6 +68,7 @@ const TPL_PARAMS = {
 const TPL_TRANSFORMS = {
   agentmd5:  ua => crypto.createHash('md5').update(ua || '').digest('hex'),
   ip:        ip => lookip.clean(ip),
+  ipmask:    ip => lookip.mask(lookip.clean(ip)),
   timestamp: ts => timestamp.toEpochMilliseconds(ts),
   randomint: (timestamp, params) => Math.floor(Math.random() * MAXINT),
   randomstr: (timestamp, params) => {

--- a/test/lookip-test.js
+++ b/test/lookip-test.js
@@ -5,6 +5,31 @@ const lookip = require('../lib/lookip');
 
 describe('lookip', () => {
 
+  it('cleans ips', () => {
+    expect(lookip.clean('')).to.equal(undefined);
+    expect(lookip.clean(',blah')).to.equal(undefined);
+    expect(lookip.clean(',999.999.999.999')).to.equal('999.999.999.999');
+    expect(lookip.clean(', , 66.6.44.4 ,99.99.99.99')).to.equal('66.6.44.4');
+  });
+
+  it('cleans a list of ips', () => {
+    expect(lookip.cleanAll('')).to.equal(undefined);
+    expect(lookip.cleanAll(',blah')).to.equal(undefined);
+    expect(lookip.cleanAll(', , 66.6.44.4 ,99.99.99.99, blah')).to.equal('66.6.44.4, 99.99.99.99');
+  });
+
+  it('masks ips', () => {
+    expect(lookip.mask('blah')).to.equal('blah');
+    expect(lookip.mask('1234.5678.1234.5678')).to.equal('1234.5678.1234.5678');
+    expect(lookip.mask('192.168.0.1')).to.equal('192.168.0.0');
+    expect(lookip.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65:1:3:3561:0');
+  });
+
+  it('masks the leftmost x-forwarded-for ip', () => {
+    expect(lookip.maskLeft('66.6.44.4, 99.99.99.99')).to.equal('66.6.44.0, 99.99.99.99');
+    expect(lookip.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal('unknown, 99.99.99.99, 127.0.0.1');
+  });
+
   it('looks up geo data', () => {
     return lookip.look('66.6.44.4').then(look => {
       expect(look.city).to.equal(5128581);

--- a/test/urlutil-test.js
+++ b/test/urlutil-test.js
@@ -65,6 +65,15 @@ describe('urlutil', () => {
     expect(url3).to.equal('http://foo.bar/');
   });
 
+  it('masks ip addresses', () => {
+    let url1 = urlutil.expand('http://foo.bar/{?ipmask}', TEST_IMPRESSION());
+    let url2 = urlutil.expand('http://foo.bar/{?ipmask}', TEST_IMPRESSION('remoteIp', '  what , 127.0.0.1'));
+    let url3 = urlutil.expand('http://foo.bar/{?ipmask}', TEST_IMPRESSION('remoteIp', '  '));
+    expect(url1).to.equal('http://foo.bar/?ipmask=127.0.0.0');
+    expect(url2).to.equal('http://foo.bar/?ipmask=127.0.0.0');
+    expect(url3).to.equal('http://foo.bar/');
+  });
+
   it('returns timestamps in milliseconds', () => {
     let url1 = urlutil.expand('http://foo.bar/{?timestamp}', TEST_IMPRESSION());
     let url2 = urlutil.expand('http://foo.bar/{?timestamp}', TEST_IMPRESSION('timestamp', 1507234920010));


### PR DESCRIPTION
For #40.

1. Make a best-effort to mask the leftmost IP in the x-forwarded-for header of pingbacks.  Invalid IPs will be left alone (you can't geo locate them anyways).
2. Add a new `ipmask` url template param that can be used in pingbacks.