### PR TITLE
JSON logging

### DIFF
--- a/lib/inputs/index.js
+++ b/lib/inputs/index.js
@@ -45,7 +45,7 @@ class Inputs {
     if (this._types.length) {
       return Promise.all(this._types.map(t => t.insert())).then(results => {
         return results.reduce((a, b) => a.concat(b), []).map(r => {
-          logger.info(`Inserted ${r.count} rows into ${r.dest}`);
+          logger.info(`Inserted ${r.count} rows into ${r.dest}`, {dest: r.dest, rows: r.count});
           return r;
         });
       });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,10 +1,12 @@
+const log = require('lambda-log');
+
 /**
  * Standard loggers (with prefixes so they're easy to search for)
  */
-exports.log = msg => console.log('[LOG]', msg);
-exports.info = msg => console.info('[INFO]', msg);
-exports.warn = msg => console.warn('[WARN]', msg);
-exports.error = msg => console.error('[ERROR]', msg);
+exports.log = function() { return log.info.apply(null, arguments); };
+exports.info = function() { return log.info.apply(null, arguments); };
+exports.warn = function() { return log.warn.apply(null, arguments); };
+exports.error = function() { return log.error.apply(null, arguments); };
 
 /**
  * Error decoding/logging (some bigquery errors are very nested)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "aws-sdk": "^2.395.0",
     "follow-redirects": "1.7.0",
     "ip": "^1.1.5",
+    "lambda-log": "^2.3.0",
     "maxmind": "^2.12.0",
     "prx-podagent": "0.1.0",
     "redis": "^2.8.0",

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -24,7 +24,7 @@ describe('handler', () => {
     infos = [];
     warns = [];
     errs = [];
-    sinon.stub(logger, 'info').callsFake(msg => infos.push(msg));
+    sinon.stub(logger, 'info').callsFake((msg, meta) => infos.push({msg, meta}));
     sinon.stub(logger, 'error').callsFake(msg => errs.push(msg));
     sinon.stub(logger, 'warn').callsFake(msg => warns.push(msg));
   });
@@ -69,9 +69,12 @@ describe('handler', () => {
     expect(infos.length).to.equal(4);
     expect(warns.length).to.equal(0);
     expect(errs.length).to.equal(0);
-    expect(infos[0]).to.match(/1 rows into dt_downloads/);
-    expect(infos[1]).to.match(/1 rows into dt_downloads_preview/);
-    expect(infos[2]).to.match(/3 rows into dt_impressions/);
+    expect(infos[0].msg).to.match(/1 rows into dt_downloads/);
+    expect(infos[0].meta).to.contain({dest: 'dt_downloads', rows: 1});
+    expect(infos[1].msg).to.match(/1 rows into dt_downloads_preview/);
+    expect(infos[1].meta).to.contain({dest: 'dt_downloads_preview', rows: 1});
+    expect(infos[2].msg).to.match(/3 rows into dt_impressions/);
+    expect(infos[2].meta).to.contain({dest: 'dt_impressions', rows: 3});
 
     // based on test-records
     expect(inserted).to.have.keys('dt_downloads', 'dt_downloads_preview', 'dt_impressions', 'pixels');
@@ -186,8 +189,10 @@ describe('handler', () => {
     expect(infos.length).to.equal(2);
     expect(warns.length).to.equal(1);
     expect(errs.length).to.equal(0);
-    expect(infos[0]).to.match(/inserted 2 rows into dynamodb/i);
-    expect(infos[1]).to.match(/inserted 1 rows into kinesis/i);
+    expect(infos[0].msg).to.match(/inserted 2 rows into dynamodb/i);
+    expect(infos[0].meta).to.contain({dest: 'dynamodb', rows: 2});
+    expect(infos[1].msg).to.match(/inserted 1 rows into kinesis/i);
+    expect(infos[1].meta).to.contain({dest: 'kinesis:foobar_stream', rows: 1});
     expect(warns[0]).to.match(/missing segment listener-episode-3.the-digest.4/i);
 
     expect(dynamo.write.args[0][0].length).to.equal(2);
@@ -221,7 +226,8 @@ describe('handler', () => {
     expect(infos.length).to.equal(1);
     expect(warns.length).to.equal(1);
     expect(errs.length).to.equal(0);
-    expect(infos[0]).to.match(/2 rows into www.foo.bar/);
+    expect(infos[0].msg).to.match(/2 rows into www.foo.bar/);
+    expect(infos[0].meta).to.contain({dest: 'www.foo.bar', rows: 2});
     expect(warns[0]).to.match(/PINGFAIL error: http 404/i);
     expect(warns[0]).to.match(/ping2/);
 
@@ -238,7 +244,8 @@ describe('handler', () => {
     expect(infos.length).to.equal(1);
     expect(warns.length).to.equal(0);
     expect(errs.length).to.equal(0);
-    expect(infos[0]).to.match(/4 rows into redis:/);
+    expect(infos[0].msg).to.match(/4 rows into redis:/);
+    expect(infos[0].meta).to.contain({dest: 'redis://127.0.0.1', rows: 4});
 
     let keys = [
       support.redisKeys('downloads.episodes.*'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,11 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-safe-stringify@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
+  integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
+
 follow-redirects@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
@@ -793,6 +798,13 @@ jws@^3.1.5:
   dependencies:
     jwa "^1.2.0"
     safe-buffer "^5.0.1"
+
+lambda-log@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/lambda-log/-/lambda-log-2.3.0.tgz#2c8b3f9e29ed6a5d2c1a9acadcadfd423be0bb75"
+  integrity sha512-L0q4b9/K/2wH2DNra4mkDXA7naCJ/7aqBhss+nNyGa8Zf74J2q7flLh4RDUPUquXFRYidNURfTGrBOucuLGiUg==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
 
 levn@~0.3.0:
   version "0.3.0"


### PR DESCRIPTION
For PRX/Infrastructure#331

Switch to json logging, as it's easier/safer to use with CloudWatch log metrics.  Some complicated juggling to deploy - see PRX/Infrastructure#336.

Also adds some `PROCESS_BEFORE` and `PROCESS_AFTER` envs.

When running the "integration tests" (via `npm start`), output looks like:

```
Running BIGQUERY
{"_logLevel":"info","msg":"Inserted 1 rows into dt_downloads","dest":"dt_downloads","rows":1,"_tags":["log","info"]}
{"_logLevel":"info","msg":"Inserted 1 rows into dt_downloads_preview","dest":"dt_downloads_preview","rows":1,"_tags":["log","info"]}
{"_logLevel":"info","msg":"Inserted 3 rows into dt_impressions","dest":"dt_impressions","rows":3,"_tags":["log","info"]}
{"_logLevel":"info","msg":"Inserted 1 rows into dt_impressions_preview","dest":"dt_impressions_preview","rows":1,"_tags":["log","info"]}
{"_logLevel":"info","msg":"Inserted 2 rows into development.pixels","dest":"development.pixels","rows":2,"_tags":["log","info"]}
Exited success: Inserted 8 rows

Running DYNAMODB
{"_logLevel":"warn","msg":"DDB missing segment listener-episode-3.the-digest.4","_tags":["log","warn"]}
{"_logLevel":"info","msg":"Inserted 2 rows into dynamodb","dest":"dynamodb","rows":2,"_tags":["log","info"]}
{"_logLevel":"info","msg":"Inserted 2 rows into kinesis:ryan-dt-range-test","dest":"kinesis:ryan-dt-range-test","rows":2,"_tags":["log","info"]}
Exited success: Inserted 4 rows

Running PINGBACKS
{"_logLevel":"warn","msg":"PINGFAIL Error: HTTP 404 from http://dovetail.prxu.org","_tags":["log","warn"]}
{"_logLevel":"warn","msg":"PINGFAIL Error: HTTP 404 from https://dovetail.prxu.org/1382066911","_tags":["log","warn"]}
{"_logLevel":"info","msg":"Inserted 2 rows into dovetail.prxu.org","dest":"dovetail.prxu.org","rows":2,"_tags":["log","info"]}
Exited success: Inserted 2 rows

Running REDIS
{"_logLevel":"info","msg":"Inserted 4 rows into redis://127.0.0.1","dest":"redis://127.0.0.1","rows":4,"_tags":["log","info"]}
Exited success: Inserted 4 rows
```