### PR TITLE
Mark bots as duplicates

### DIFF
--- a/lib/assayer.js
+++ b/lib/assayer.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const geolocate = require('./assays/geolocate')
+const useragent = require('./assays/useragent')
+
+/**
+ * Determine if a download is a duplicate, and return metadata.
+ */
+exports.test = async (record, includeGeo = false) => {
+  const [geo, agent] = await Promise.all([
+    includeGeo ? geolocate.look(record.remoteIp) : null,
+    useragent.look(record.remoteAgent)
+  ])
+  if (record.download && record.download.isDuplicate) {
+    return {isDuplicate: true, cause: record.download.cause || 'unknown', geo, agent}
+  } else if (agent.bot) {
+    return {isDuplicate: true, cause: 'bot', geo, agent}
+  } else {
+    return {isDuplicate: false, cause: null, geo, agent}
+  }
+}
+
+/**
+ * Test an impression within the download record
+ */
+exports.testImpression = async (record, impression, includeGeo = false) => {
+  const [geo, agent] = await Promise.all([
+    includeGeo ? geolocate.look(record.remoteIp) : null,
+    useragent.look(record.remoteAgent)
+  ])
+  if (impression.isDuplicate) {
+    return {isDuplicate: true, cause: impression.cause || 'unknown', geo, agent}
+  } else if (agent.bot) {
+    return {isDuplicate: true, cause: 'bot', geo, agent}
+  } else {
+    return {isDuplicate: false, cause: null, geo, agent}
+  }
+}

--- a/lib/assayer.js
+++ b/lib/assayer.js
@@ -14,7 +14,7 @@ exports.test = async (record, includeGeo = false) => {
   if (record.download && record.download.isDuplicate) {
     return {isDuplicate: true, cause: record.download.cause || 'unknown', geo, agent}
   } else if (agent.bot) {
-    return {isDuplicate: true, cause: 'bot', geo, agent}
+    return {isDuplicate: false, cause: 'bot', geo, agent} // TODO: bot-filter preview
   } else {
     return {isDuplicate: false, cause: null, geo, agent}
   }
@@ -31,7 +31,7 @@ exports.testImpression = async (record, impression, includeGeo = false) => {
   if (impression.isDuplicate) {
     return {isDuplicate: true, cause: impression.cause || 'unknown', geo, agent}
   } else if (agent.bot) {
-    return {isDuplicate: true, cause: 'bot', geo, agent}
+    return {isDuplicate: false, cause: 'bot', geo, agent} // TODO: bot-filter preview
   } else {
     return {isDuplicate: false, cause: null, geo, agent}
   }

--- a/lib/assays/geolocate.js
+++ b/lib/assays/geolocate.js
@@ -1,7 +1,8 @@
 'use strict';
-const ip = require('ip');
+
 const maxmind = require('maxmind');
-const dbfile = `${__dirname}/../db/GeoLite2-City.mmdb`;
+const iputil = require('../iputil');
+const dbfile = `${__dirname}/../../db/GeoLite2-City.mmdb`;
 
 // maxmind singleton
 let _maxdb;
@@ -22,46 +23,12 @@ function maxdb() {
 }
 
 /**
- * Sanity check ip addresses
- */
-exports.clean = (ipString) => {
-  return exports.cleanAll(ipString, false)[0];
-}
-exports.cleanAll = (xffString, join = true) => {
-  let parts = (xffString || '').split(',').map(s => s.trim());
-  let cleaned = parts.filter(s => s && (ip.isV4Format(s) || ip.isV6Format(s)));
-  if (join) {
-    return cleaned.join(', ') || undefined;
-  } else {
-    return cleaned;
-  }
-}
-
-/**
- * Bitmask ip to remove last octet(s)
- */
-exports.mask = (cleanIpString) => {
-  if (ip.isV4Format(cleanIpString)) {
-    return ip.mask(cleanIpString, '255.255.255.0');
-  } else if (ip.isV6Format(cleanIpString)) {
-    return ip.mask(cleanIpString, 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:0');
-  } else {
-    return cleanIpString;
-  }
-}
-exports.maskLeft = (cleanXffString) => {
-  const parts = (cleanXffString || '').split(', ');
-  parts[0] = exports.mask(parts[0]);
-  return parts.join(', ');
-}
-
-/**
  * Lookup the geoid of the city geo name for an IP
  */
 exports.look = (ipString) => {
   return maxdb().then(
     maxdb => {
-      let cleaned = exports.clean(ipString);
+      let cleaned = iputil.clean(ipString);
       if (cleaned) {
         let loc = maxdb.get(cleaned);
         return {
@@ -70,7 +37,7 @@ exports.look = (ipString) => {
           postal: (loc && loc.postal) ? loc.postal.code : null,
           latitude: (loc && loc.location) ? loc.location.latitude : null,
           longitude: (loc && loc.location) ? loc.location.longitude : null,
-          masked: exports.mask(cleaned)
+          masked: iputil.mask(cleaned)
         };
       } else {
         return {city: null, country: null, postal: null, latitude: null, longitude: null, masked: null};

--- a/lib/assays/useragent.js
+++ b/lib/assays/useragent.js
@@ -15,7 +15,7 @@ exports.look = (agentString) => {
         if (agent) {
           resolve({name: agent.nameId, type: agent.typeId, os: agent.osId, bot: agent.bot});
         } else {
-          resolve({name: null, type: null, os: null, bot: null});
+          resolve({name: null, type: null, os: null, bot: false});
         }
       }
     });

--- a/lib/assays/useragent.js
+++ b/lib/assays/useragent.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const podagent = require('prx-podagent');
 
 /**
@@ -12,9 +13,9 @@ exports.look = (agentString) => {
         reject(err);
       } else {
         if (agent) {
-          resolve({name: agent.nameId, type: agent.typeId, os: agent.osId});
+          resolve({name: agent.nameId, type: agent.typeId, os: agent.osId, bot: agent.bot});
         } else {
-          resolve({name: null, type: null, os: null});
+          resolve({name: null, type: null, os: null, bot: null});
         }
       }
     });

--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -2,8 +2,7 @@
 
 const uuidv4 = require('uuid/v4');
 const timestamp = require('../timestamp');
-const lookip = require('../lookip');
-const lookagent = require('../lookagent');
+const assayer = require('../assayer');
 const bigquery = require('../bigquery');
 
 /**
@@ -60,8 +59,7 @@ module.exports = class DovetailDownloads {
   async format(record) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
     const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
-    const lookups = [lookip.look(record.remoteIp), lookagent.look(record.remoteAgent)];
-    const [geo, agent] = await Promise.all(lookups);
+    const info = await assayer.test(record, true);
 
     return {
       insertId: `${listenerSession}/${epoch}`,
@@ -73,8 +71,8 @@ module.exports = class DovetailDownloads {
         feeder_episode:     record.feederEpisode,
         digest:             record.digest,
         ad_count:           record.download.adCount,
-        is_duplicate:       !!record.download.isDuplicate,
-        cause:              record.download.cause,
+        is_duplicate:       info.isDuplicate,
+        cause:              info.cause,
         is_confirmed:       !!record.confirmed,
         is_bytes:           this.isBytes(record),
         url:                record.url,
@@ -85,16 +83,16 @@ module.exports = class DovetailDownloads {
         // request data
         remote_referrer:    record.remoteReferrer,
         remote_agent:       record.remoteAgent,
-        remote_ip:          geo.masked,
+        remote_ip:          info.geo.masked,
         // derived data
-        agent_name_id:      agent.name,
-        agent_type_id:      agent.type,
-        agent_os_id:        agent.os,
-        city_geoname_id:    geo.city,
-        country_geoname_id: geo.country,
-        postal_code:        geo.postal,
-        latitude:           geo.latitude,
-        longitude:          geo.longitude
+        agent_name_id:      info.agent.name,
+        agent_type_id:      info.agent.type,
+        agent_os_id:        info.agent.os,
+        city_geoname_id:    info.geo.city,
+        country_geoname_id: info.geo.country,
+        postal_code:        info.geo.postal,
+        latitude:           info.geo.latitude,
+        longitude:          info.geo.longitude
       }
     };
   }

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -38,17 +38,15 @@ module.exports = class DovetailImpressions {
 
     // format records and organize by table name
     const formatted = {};
-    await Promise.all(this._records.map(async (rec) => {
+    await this.eachImpression(async (rec, imp) => {
       const name = this.tableName(rec);
-      await Promise.all(rec.impressions.map(async (imp) => {
-        const formattedRec = await this.format(rec, imp);
-        if (formatted[name]) {
-          formatted[name].push(formattedRec);
-        } else {
-          formatted[name] = [formattedRec];
-        }
-      }));
-    }));
+      const formattedRec = await this.format(rec, imp);
+      if (formatted[name]) {
+        formatted[name].push(formattedRec);
+      } else {
+        formatted[name] = [formattedRec];
+      }
+    });
     const tableNames = Object.keys(formatted);
 
     // insert in parallel
@@ -99,6 +97,14 @@ module.exports = class DovetailImpressions {
 
   isBytes(record) {
     return record.type === 'postbytes' || record.type === 'postbytespreview';
+  }
+
+  async eachImpression(handler) {
+    await Promise.all(this._records.map(async (rec) => {
+      await Promise.all(rec.impressions.map(async (imp) => {
+        await handler(rec, imp);
+      }));
+    }));
   }
 
 };

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -3,6 +3,7 @@
 const uuidv4 = require('uuid/v4');
 const crypto = require('crypto');
 const timestamp = require('../timestamp');
+const assayer = require('../assayer');
 const bigquery = require('../bigquery');
 
 /**
@@ -37,16 +38,17 @@ module.exports = class DovetailImpressions {
 
     // format records and organize by table name
     const formatted = {};
-    this._records.forEach(rec => {
+    await Promise.all(this._records.map(async (rec) => {
       const name = this.tableName(rec);
-      rec.impressions.forEach(imp => {
+      await Promise.all(rec.impressions.map(async (imp) => {
+        const formattedRec = await this.format(rec, imp);
         if (formatted[name]) {
-          formatted[name].push(this.format(rec, imp));
+          formatted[name].push(formattedRec);
         } else {
-          formatted[name] = [this.format(rec, imp)];
+          formatted[name] = [formattedRec];
         }
-      });
-    });
+      }));
+    }));
     const tableNames = Object.keys(formatted);
 
     // insert in parallel
@@ -57,9 +59,11 @@ module.exports = class DovetailImpressions {
     }));
   }
 
-  format(record, imp) {
+  async format(record, imp) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
     const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
+    const info = await assayer.testImpression(record, imp);
+
     return {
       insertId: this.md5InsertId(`${listenerSession}/${epoch}`, imp),
       json: {
@@ -76,8 +80,8 @@ module.exports = class DovetailImpressions {
         campaign_id:      imp.campaignId,
         creative_id:      imp.creativeId,
         flight_id:        imp.flightId,
-        is_duplicate:     !!imp.isDuplicate,
-        cause:            imp.cause
+        is_duplicate:     info.isDuplicate,
+        cause:            info.cause
       }
     };
   }

--- a/lib/inputs/pingbacks.js
+++ b/lib/inputs/pingbacks.js
@@ -33,7 +33,8 @@ module.exports = class Pingbacks {
     let hostCounts = {};
     let pings = [];
     await this.eachImpression(async (r, i) => {
-      if (!(await assayer.testImpression(r, i)).isDuplicate) {
+      const {isDuplicate} = await assayer.testImpression(r, i);
+      if (!isDuplicate) {
         (i.pings || []).forEach(pb => {
           const url = urlutil.expand(pb, {...r, ...i});
           pings.push(this.ping(url, r, hostCounts));

--- a/lib/inputs/pingbacks.js
+++ b/lib/inputs/pingbacks.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const logger = require('../logger');
+const assayer = require('../assayer');
 const pingurl = require('../pingurl');
 const urlutil = require('../urlutil');
 
@@ -28,15 +29,16 @@ module.exports = class Pingbacks {
       return [];
     }
 
+    // filter duplicates
     let hostCounts = {};
     let pings = [];
-    this._records.forEach(r => {
-      r.impressions.filter(i => !i.isDuplicate).forEach(i => {
+    await this.eachImpression(async (r, i) => {
+      if (!(await assayer.testImpression(r, i)).isDuplicate) {
         (i.pings || []).forEach(pb => {
           const url = urlutil.expand(pb, {...r, ...i});
           pings.push(this.ping(url, r, hostCounts));
         });
-      });
+      }
     });
 
     // ping urls, incrementing the counts per-host
@@ -53,6 +55,14 @@ module.exports = class Pingbacks {
     } catch (err) {
       logger.warn(`PINGFAIL ${err}`);
     }
+  }
+
+  async eachImpression(handler) {
+    await Promise.all(this._records.map(async (rec) => {
+      await Promise.all(rec.impressions.map(async (imp) => {
+        await handler(rec, imp);
+      }));
+    }));
   }
 
 };

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 const logger = require('../logger')
 const timestamp = require('../timestamp')
-const lookip = require('../lookip')
+const assayer = require('../assayer')
 const bigquery = require('../bigquery')
 
 /**
@@ -58,7 +58,9 @@ module.exports = class PixelTrackers {
   async format(record) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0)
     const userId = this.userId(record)
-    const geo = await lookip.look(record.remoteIp)
+    const info = await assayer.test(record, true)
+
+    // TODO: info.isDuplicates?
     return {
       insertId: this.insertId(epoch, userId, record.key, record.canonical),
       json: {
@@ -68,12 +70,12 @@ module.exports = class PixelTrackers {
         canonical:          record.canonical,
         remote_agent:       record.remoteAgent,
         remote_referrer:    record.remoteReferrer,
-        remote_ip:          geo.masked,
-        city_geoname_id:    geo.city,
-        country_geoname_id: geo.country,
-        postal_code:        geo.postal,
-        latitude:           geo.latitude,
-        longitude:          geo.longitude
+        remote_ip:          info.geo.masked,
+        city_geoname_id:    info.geo.city,
+        country_geoname_id: info.geo.country,
+        postal_code:        info.geo.postal,
+        latitude:           info.geo.latitude,
+        longitude:          info.geo.longitude
       }
     }
   }

--- a/lib/inputs/redis-increments.js
+++ b/lib/inputs/redis-increments.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const logger = require('../logger');
+const assayer = require('../assayer');
 const Redis = require('../redis');
 
 /**
@@ -20,16 +21,17 @@ module.exports = class RedisIncrements {
     return isType && isFeeder && isDownload;
   }
 
-  insert() {
+  async insert() {
     let keysToFields = {}, totalIncrements = 0;
-    this._records.forEach(r => {
-      if (r.feederPodcast) {
+    await Promise.all(this._records.map(async (r) => {
+      const {isDuplicate} = await assayer.test(r);
+      if (!isDuplicate && r.feederPodcast) {
         totalIncrements += this.addKeys(keysToFields, this.getPodcastKeys(r), r.feederPodcast);
       }
-      if (r.feederEpisode) {
+      if (!isDuplicate && r.feederEpisode) {
         totalIncrements += this.addKeys(keysToFields, this.getEpisodeKeys(r), r.feederEpisode);
       }
-    });
+    }));
 
     if (totalIncrements === 0 || !this._redis.hostName()) {
       return Promise.resolve([]);

--- a/lib/iputil.js
+++ b/lib/iputil.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const ip = require('ip');
+
+/**
+ * Sanity check ip addresses
+ */
+exports.clean = (ipString) => {
+  return exports.cleanAll(ipString, false)[0];
+}
+exports.cleanAll = (xffString, join = true) => {
+  let parts = (xffString || '').split(',').map(s => s.trim());
+  let cleaned = parts.filter(s => s && (ip.isV4Format(s) || ip.isV6Format(s)));
+  if (join) {
+    return cleaned.join(', ') || undefined;
+  } else {
+    return cleaned;
+  }
+}
+
+/**
+ * Bitmask ip to remove last octet(s)
+ */
+exports.mask = (cleanIpString) => {
+  if (ip.isV4Format(cleanIpString)) {
+    return ip.mask(cleanIpString, '255.255.255.0');
+  } else if (ip.isV6Format(cleanIpString)) {
+    return ip.mask(cleanIpString, 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:0');
+  } else {
+    return cleanIpString;
+  }
+}
+exports.maskLeft = (cleanXffString) => {
+  const parts = (cleanXffString || '').split(', ');
+  parts[0] = exports.mask(parts[0]);
+  return parts.join(', ');
+}

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -6,7 +6,7 @@ followRedirects.maxRedirects = 10;
 const http = followRedirects.http;
 const https = followRedirects.https;
 const logger = require('./logger');
-const lookip = require('./lookip');
+const iputil = require('./iputil');
 
 const TIMEOUT_MS = 5000;
 const TIMEOUT_WAIT_MS = 1000;
@@ -58,9 +58,9 @@ exports.parseHeaders = (data) => {
     headers['User-Agent'] = data.remoteAgent;
   }
   if (data && data.remoteIp) {
-    const clean = lookip.cleanAll(data.remoteIp);
+    const clean = iputil.cleanAll(data.remoteIp);
     if (clean) {
-      headers['X-Forwarded-For'] = lookip.maskLeft(clean);
+      headers['X-Forwarded-For'] = iputil.maskLeft(clean);
     }
   }
   if (data && data.remoteReferrer) {

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -3,7 +3,7 @@
 const URI = require('urijs');
 const URITemplate = require('urijs/src/URITemplate');
 const crypto = require('crypto');
-const lookip = require('./lookip');
+const iputil = require('./iputil');
 const timestamp = require('./timestamp');
 const MAXINT = 2147483647; // assume signed 32-bit int
 
@@ -67,8 +67,8 @@ const TPL_PARAMS = {
 // clean up some of the values
 const TPL_TRANSFORMS = {
   agentmd5:  ua => crypto.createHash('md5').update(ua || '').digest('hex'),
-  ip:        ip => lookip.clean(ip),
-  ipmask:    ip => lookip.mask(lookip.clean(ip)),
+  ip:        ip => iputil.clean(ip),
+  ipmask:    ip => iputil.mask(iputil.clean(ip)),
   timestamp: ts => timestamp.toEpochMilliseconds(ts),
   randomint: (timestamp, params) => Math.floor(Math.random() * MAXINT),
   randomstr: (timestamp, params) => {

--- a/test/assayer-test.js
+++ b/test/assayer-test.js
@@ -41,7 +41,7 @@ describe('assayer', () => {
 
     it('checks for bots', async () => {
       const info = await assayer.test({remoteAgent: 'googlebot'})
-      expect(info.isDuplicate).to.equal(true)
+      expect(info.isDuplicate).to.equal(false) // TODO: bot-filter preview
       expect(info.cause).to.equal('bot')
     })
 
@@ -83,7 +83,7 @@ describe('assayer', () => {
 
     it('checks for bots', async () => {
       const info = await assayer.testImpression({remoteAgent: 'googlebot'}, {isDuplicate: false})
-      expect(info.isDuplicate).to.equal(true)
+      expect(info.isDuplicate).to.equal(false) // TODO: bot-filter preview
       expect(info.cause).to.equal('bot')
     })
 

--- a/test/assayer-test.js
+++ b/test/assayer-test.js
@@ -1,0 +1,92 @@
+'use strict'
+
+const support = require('./support')
+const assayer = require('../lib/assayer')
+
+describe('assayer', () => {
+
+  describe('test', () => {
+
+    it('returns basic info', async () => {
+      const info = await assayer.test({remoteAgent: 'something'})
+      expect(info).to.eql({
+        isDuplicate: false,
+        cause: null,
+        geo: null,
+        agent: {name: null, type: null, os: null, bot: false}
+      })
+    })
+
+    it('optionally geo locates', async () => {
+      const info = await assayer.test({remoteAgent: 'Pocket Casts', remoteIp: '127.0.0.1'}, true)
+      expect(info).to.eql({
+        isDuplicate: false,
+        cause: null,
+        geo: {city: null, country: null, latitude: null, longitude: null, masked: '127.0.0.0', postal: null},
+        agent: {name: 16, type: 36, os: null, bot: false}
+      })
+    })
+
+    it('checks the download duplicate', async () => {
+      const info = await assayer.test({download: {isDuplicate: true, cause: 'foo'}, remoteAgent: 'googlebot'})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('foo')
+    })
+
+    it('has a default cause', async () => {
+      const info = await assayer.test({download: {isDuplicate: true}, remoteAgent: 'googlebot'})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('unknown')
+    })
+
+    it('checks for bots', async () => {
+      const info = await assayer.test({remoteAgent: 'googlebot'})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('bot')
+    })
+
+  })
+
+  describe('testImpression', async () => {
+
+    it('returns basic info', async () => {
+      const info = await assayer.testImpression({remoteAgent: 'something'}, {})
+      expect(info).to.eql({
+        isDuplicate: false,
+        cause: null,
+        geo: null,
+        agent: {name: null, type: null, os: null, bot: false}
+      })
+    })
+
+    it('optionally geo locates', async () => {
+      const info = await assayer.testImpression({remoteAgent: 'Pocket Casts', remoteIp: '127.0.0.1'}, {}, true)
+      expect(info).to.eql({
+        isDuplicate: false,
+        cause: null,
+        geo: {city: null, country: null, latitude: null, longitude: null, masked: '127.0.0.0', postal: null},
+        agent: {name: 16, type: 36, os: null, bot: false}
+      })
+    })
+
+    it('checks the download duplicate', async () => {
+      const info = await assayer.testImpression({remoteAgent: 'googlebot'}, {isDuplicate: true, cause: 'foo'})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('foo')
+    })
+
+    it('has a default cause', async () => {
+      const info = await assayer.testImpression({remoteAgent: 'googlebot'}, {isDuplicate: true})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('unknown')
+    })
+
+    it('checks for bots', async () => {
+      const info = await assayer.testImpression({remoteAgent: 'googlebot'}, {isDuplicate: false})
+      expect(info.isDuplicate).to.equal(true)
+      expect(info.cause).to.equal('bot')
+    })
+
+  })
+
+})

--- a/test/assays-geolocate-test.js
+++ b/test/assays-geolocate-test.js
@@ -1,37 +1,12 @@
 'use strict';
 
 const support   = require('./support');
-const lookip = require('../lib/lookip');
+const geo = require('../lib/assays/geolocate');
 
-describe('lookip', () => {
-
-  it('cleans ips', () => {
-    expect(lookip.clean('')).to.equal(undefined);
-    expect(lookip.clean(',blah')).to.equal(undefined);
-    expect(lookip.clean(',999.999.999.999')).to.equal('999.999.999.999');
-    expect(lookip.clean(', , 66.6.44.4 ,99.99.99.99')).to.equal('66.6.44.4');
-  });
-
-  it('cleans a list of ips', () => {
-    expect(lookip.cleanAll('')).to.equal(undefined);
-    expect(lookip.cleanAll(',blah')).to.equal(undefined);
-    expect(lookip.cleanAll(', , 66.6.44.4 ,99.99.99.99, blah')).to.equal('66.6.44.4, 99.99.99.99');
-  });
-
-  it('masks ips', () => {
-    expect(lookip.mask('blah')).to.equal('blah');
-    expect(lookip.mask('1234.5678.1234.5678')).to.equal('1234.5678.1234.5678');
-    expect(lookip.mask('192.168.0.1')).to.equal('192.168.0.0');
-    expect(lookip.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65:1:3:3561:0');
-  });
-
-  it('masks the leftmost x-forwarded-for ip', () => {
-    expect(lookip.maskLeft('66.6.44.4, 99.99.99.99')).to.equal('66.6.44.0, 99.99.99.99');
-    expect(lookip.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal('unknown, 99.99.99.99, 127.0.0.1');
-  });
+describe('geolocate', () => {
 
   it('looks up geo data', () => {
-    return lookip.look('66.6.44.4').then(look => {
+    return geo.look('66.6.44.4').then(look => {
       expect(look.city).to.equal(5128581);
       expect(look.country).to.equal(6252001);
       expect(look.postal).to.equal('10010');
@@ -42,7 +17,7 @@ describe('lookip', () => {
   });
 
   it('handle unlocate-able ips', () => {
-    return lookip.look('192.168.0.1').then(look => {
+    return geo.look('192.168.0.1').then(look => {
       expect(look.city).to.be.null;
       expect(look.country).to.be.null;
       expect(look.postal).to.be.null;
@@ -53,7 +28,7 @@ describe('lookip', () => {
   });
 
   it('handle blanks', () => {
-    return lookip.look('').then(look => {
+    return geo.look('').then(look => {
       expect(look.city).to.be.null;
       expect(look.country).to.be.null;
       expect(look.postal).to.be.null;
@@ -64,7 +39,7 @@ describe('lookip', () => {
   });
 
   it('handle nonsense', () => {
-    return lookip.look('ontehunteho').then(look => {
+    return geo.look('ontehunteho').then(look => {
       expect(look.city).to.be.null;
       expect(look.country).to.be.null;
       expect(look.postal).to.be.null;
@@ -75,7 +50,7 @@ describe('lookip', () => {
   });
 
   it('splits forwarded-for ips', () => {
-    return lookip.look('66.6.44.4, 99.99.99.99, 127.0.0.1').then(look => {
+    return geo.look('66.6.44.4, 99.99.99.99, 127.0.0.1').then(look => {
       expect(look.city).to.equal(5128581);
       expect(look.country).to.equal(6252001);
       expect(look.postal).to.equal('10010');
@@ -86,7 +61,7 @@ describe('lookip', () => {
   });
 
   it('removes unknowns', () => {
-    return lookip.look('unknown,66.6.44.4').then(look => {
+    return geo.look('unknown,66.6.44.4').then(look => {
       expect(look.city).to.equal(5128581);
       expect(look.country).to.equal(6252001);
       expect(look.postal).to.equal('10010');
@@ -97,7 +72,7 @@ describe('lookip', () => {
   });
 
   it('removes blanks', () => {
-    return lookip.look(', , 66.6.44.4 ,99.99.99.99').then(look => {
+    return geo.look(', , 66.6.44.4 ,99.99.99.99').then(look => {
       expect(look.city).to.equal(5128581);
       expect(look.country).to.equal(6252001);
       expect(look.postal).to.equal('10010');
@@ -108,7 +83,7 @@ describe('lookip', () => {
   });
 
   it('handles ipv6', () => {
-    return lookip.look('blah,blah, 2804:18:1012:6b65:1:3:3561:14b8').then(look => {
+    return geo.look('blah,blah, 2804:18:1012:6b65:1:3:3561:14b8').then(look => {
       expect(look.city).to.equal(3448439);
       expect(look.country).to.equal(3469034);
       expect(look.postal).to.equal('01000');

--- a/test/assays-useragent-test.js
+++ b/test/assays-useragent-test.js
@@ -10,6 +10,7 @@ describe('useragent', () => {
       expect(look.name).to.equal(23);
       expect(look.type).to.equal(36);
       expect(look.os).to.equal(42);
+      expect(look.bot).to.equal(false);
     });
   });
 
@@ -18,6 +19,7 @@ describe('useragent', () => {
       expect(look.name).to.be.null;
       expect(look.type).to.equal(40);
       expect(look.os).to.equal(42);
+      expect(look.bot).to.equal(false);
     });
   });
 
@@ -26,6 +28,7 @@ describe('useragent', () => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
+      expect(look.bot).to.equal(false);
     });
   });
 
@@ -34,6 +37,16 @@ describe('useragent', () => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
+      expect(look.bot).to.equal(false);
+    });
+  });
+
+  it('handle bots', () => {
+    return agent.look('googlebot').then(look => {
+      expect(look.name).to.be.null;
+      expect(look.type).to.be.null;
+      expect(look.os).to.be.null;
+      expect(look.bot).to.equal(true);
     });
   });
 
@@ -43,11 +56,13 @@ describe('useragent', () => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
+      expect(look.bot).to.equal(false);
       return agent.look(`${str}  `);
     }).then(look => {
       expect(look.name).to.equal(11);
       expect(look.type).to.equal(36);
       expect(look.os).to.equal(43);
+      expect(look.bot).to.equal(false);
     });
   });
 

--- a/test/assays-useragent-test.js
+++ b/test/assays-useragent-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const support = require('./support');
-const lookagent = require('../lib/lookagent');
+const agent = require('../lib/assays/useragent');
 
-describe('lookagent', () => {
+describe('useragent', () => {
 
   it('looks up agent strings', () => {
-    return lookagent.look('Stitcher/Android').then(look => {
+    return agent.look('Stitcher/Android').then(look => {
       expect(look.name).to.equal(23);
       expect(look.type).to.equal(36);
       expect(look.os).to.equal(42);
@@ -14,7 +14,7 @@ describe('lookagent', () => {
   });
 
   it('handle partial matching agents', () => {
-    return lookagent.look('Mozilla/5.0 (Linux; U; Android 6.0.1;px5/MXC89L)').then(look => {
+    return agent.look('Mozilla/5.0 (Linux; U; Android 6.0.1;px5/MXC89L)').then(look => {
       expect(look.name).to.be.null;
       expect(look.type).to.equal(40);
       expect(look.os).to.equal(42);
@@ -22,7 +22,7 @@ describe('lookagent', () => {
   });
 
   it('handles blanks', () => {
-    return lookagent.look('').then(look => {
+    return agent.look('').then(look => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
@@ -30,7 +30,7 @@ describe('lookagent', () => {
   });
 
   it('handle nonsense', () => {
-    return lookagent.look('ontehunteho').then(look => {
+    return agent.look('ontehunteho').then(look => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
@@ -39,11 +39,11 @@ describe('lookagent', () => {
 
   it('respects blanks', () => {
     let str = 'Downcast/2.9.16 (iPhone; iOS 10.3.2; Scale/2.00)';
-    return lookagent.look(` ${str}`).then(look => {
+    return agent.look(` ${str}`).then(look => {
       expect(look.name).to.be.null;
       expect(look.type).to.be.null;
       expect(look.os).to.be.null;
-      return lookagent.look(`${str}  `);
+      return agent.look(`${str}  `);
     }).then(look => {
       expect(look.name).to.equal(11);
       expect(look.type).to.equal(36);

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -32,10 +32,10 @@ describe('dovetail-impressions', () => {
     expect(impression.isBytes({type: 'postbytespreview'})).to.be.true;
   });
 
-  it('formats table inserts', () => {
+  it('formats table inserts', async () => {
     const rec = {type: 'combined', timestamp: 1490827132999, listenerEpisode: 'something'};
 
-    const format1 = impression.format(rec, {adId: 1, isDuplicate: true});
+    const format1 = await impression.format(rec, {adId: 1, isDuplicate: true});
     expect(format1).to.have.keys('insertId', 'json');
     expect(format1.insertId.length).to.be.above(10);
     expect(format1.json).to.have.keys(
@@ -49,18 +49,18 @@ describe('dovetail-impressions', () => {
     expect(format1.json.listener_session.length).to.be.above(10);
     expect(format1.json.is_duplicate).to.equal(true);
 
-    const format2 = impression.format(rec, {adId: 2, isDuplicate: false});
+    const format2 = await impression.format(rec, {adId: 2, isDuplicate: false});
     expect(format2.json.timestamp).to.equal(1490827132);
     expect(format2.json.listener_session).to.equal(format1.json.listener_session);
     expect(format2.json.is_duplicate).to.equal(false);
     expect(format2.insertId).not.to.equal(format1.insertId);
   });
 
-  it('creates unique insert ids for ads', () => {
-    const r1 = impression.format({listenerEpisode: 'req1'}, {adId: 1});
-    const r2 = impression.format({listenerEpisode: 'req1'}, {adId: 1});
-    const r3 = impression.format({listenerEpisode: 'req1'}, {adId: 2});
-    const r4 = impression.format({listenerEpisode: 'req2'}, {adId: 1});
+  it('creates unique insert ids for ads', async () => {
+    const r1 = await impression.format({listenerEpisode: 'req1'}, {adId: 1});
+    const r2 = await impression.format({listenerEpisode: 'req1'}, {adId: 1});
+    const r3 = await impression.format({listenerEpisode: 'req1'}, {adId: 2});
+    const r4 = await impression.format({listenerEpisode: 'req2'}, {adId: 1});
     expect(r1.insertId).to.equal(r2.insertId);
     expect(r1.insertId).not.to.equal(r3.insertId);
     expect(r1.insertId).not.to.equal(r4.insertId);

--- a/test/inputs-pingbacks-test.js
+++ b/test/inputs-pingbacks-test.js
@@ -85,6 +85,7 @@ describe('pingbacks', () => {
   });
 
   it('does not ping duplicate records', async () => {
+    nock('http://foo.bar').get('/ping1').reply(200); // TODO: bot-filter preview
     sinon.stub(logger, 'warn');
     pingbacks = new Pingbacks([
       {
@@ -96,7 +97,7 @@ describe('pingbacks', () => {
     expect(pingbacks._records.length).to.equal(1);
 
     const result = await pingbacks.insert();
-    expect(result.length).to.equal(0);
+    expect(result.length).to.equal(1); // TODO: bot-filter preview
     expect(logger.warn).not.to.have.been.called;
   })
 

--- a/test/inputs-pingbacks-test.js
+++ b/test/inputs-pingbacks-test.js
@@ -84,4 +84,20 @@ describe('pingbacks', () => {
     expect(warns.sort()[5]).to.match(/PINGRETRY/);
   });
 
+  it('does not ping duplicate records', async () => {
+    sinon.stub(logger, 'warn');
+    pingbacks = new Pingbacks([
+      {
+        type: 'combined',
+        remoteAgent: 'googlebot',
+        impressions: [{adId: 11, isDuplicate: false, pings: ['http://foo.bar/ping1']}]
+      }
+    ]);
+    expect(pingbacks._records.length).to.equal(1);
+
+    const result = await pingbacks.insert();
+    expect(result.length).to.equal(0);
+    expect(logger.warn).not.to.have.been.called;
+  })
+
 });

--- a/test/inputs-redis-increments-test.js
+++ b/test/inputs-redis-increments-test.js
@@ -56,7 +56,7 @@ describe('redis-increments', () => {
     ]);
     expect(incr._records.length).to.equal(1);
     let result = await incr.insert();
-    expect(result.length).to.equal(0);
+    expect(result.length).to.equal(1); // TODO: bot-filter preview
   });
 
   it('increments redis counts', () => {

--- a/test/inputs-redis-increments-test.js
+++ b/test/inputs-redis-increments-test.js
@@ -50,6 +50,15 @@ describe('redis-increments', () => {
     });
   });
 
+  it('does not increment duplicate records', async () => {
+    let incr = new RedisIncrements([
+      {...record(1490827132, 'combined', 1234, 'abcd'), remoteAgent: 'googlebot'}
+    ]);
+    expect(incr._records.length).to.equal(1);
+    let result = await incr.insert();
+    expect(result.length).to.equal(0);
+  });
+
   it('increments redis counts', () => {
     let incr = new RedisIncrements([
       record(1490827132, 'download', 1234, 'abcd'),

--- a/test/iputil-test.js
+++ b/test/iputil-test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const support = require('./support');
+const iputil = require('../lib/iputil');
+
+describe('iputil', () => {
+
+  it('cleans ips', () => {
+    expect(iputil.clean('')).to.equal(undefined);
+    expect(iputil.clean(',blah')).to.equal(undefined);
+    expect(iputil.clean(',999.999.999.999')).to.equal('999.999.999.999');
+    expect(iputil.clean(', , 66.6.44.4 ,99.99.99.99')).to.equal('66.6.44.4');
+  });
+
+  it('cleans a list of ips', () => {
+    expect(iputil.cleanAll('')).to.equal(undefined);
+    expect(iputil.cleanAll(',blah')).to.equal(undefined);
+    expect(iputil.cleanAll(', , 66.6.44.4 ,99.99.99.99, blah')).to.equal('66.6.44.4, 99.99.99.99');
+  });
+
+  it('masks ips', () => {
+    expect(iputil.mask('blah')).to.equal('blah');
+    expect(iputil.mask('1234.5678.1234.5678')).to.equal('1234.5678.1234.5678');
+    expect(iputil.mask('192.168.0.1')).to.equal('192.168.0.0');
+    expect(iputil.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65:1:3:3561:0');
+  });
+
+  it('masks the leftmost x-forwarded-for ip', () => {
+    expect(iputil.maskLeft('66.6.44.4, 99.99.99.99')).to.equal('66.6.44.0, 99.99.99.99');
+    expect(iputil.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal('unknown, 99.99.99.99, 127.0.0.1');
+  });
+
+});


### PR DESCRIPTION
For #46.  Filter out requests that prx-podagent recognizes as "bots".