### PR TITLE
Handle pingback url parsing errors

### DIFF
--- a/lib/inputs/pingbacks.js
+++ b/lib/inputs/pingbacks.js
@@ -36,8 +36,12 @@ module.exports = class Pingbacks {
       const {isDuplicate} = await assayer.testImpression(r, i);
       if (!isDuplicate) {
         (i.pings || []).forEach(pb => {
-          const url = urlutil.expand(pb, {...r, ...i});
-          pings.push(this.ping(url, r, hostCounts));
+          try {
+            const url = urlutil.expand(pb, {...r, ...i});
+            pings.push(this.ping(url, r, hostCounts));
+          } catch (err) {
+            logger.error(`PINGFAIL ${err}`);
+          }
         });
       }
     });

--- a/test/inputs-pingbacks-test.js
+++ b/test/inputs-pingbacks-test.js
@@ -62,11 +62,15 @@ describe('pingbacks', () => {
       ]},
       {type: 'combined', impressions: [
         {isDuplicate: false, pings: ['http://foo.bar/ping2', 'http://bar.foo/ping3']}
+      ]},
+      {type: 'combined', impressions: [
+        {isDuplicate: false, pings: ['https://pingback.podtrac.com/<showid>/<adid>/<pos>?IP={ip}']}
       ]}
     ], 1000, 0);
 
-    let warns = [];
+    let warns = [], errors = [];
     sinon.stub(logger, 'warn').callsFake(msg => warns.push(msg));
+    sinon.stub(logger, 'error').callsFake(msg => errors.push(msg));
 
     const result = await pingbacks.insert();
     expect(result.length).to.equal(1);
@@ -82,6 +86,10 @@ describe('pingbacks', () => {
     expect(warns.sort()[3]).to.match(/PINGRETRY/);
     expect(warns.sort()[4]).to.match(/PINGRETRY/);
     expect(warns.sort()[5]).to.match(/PINGRETRY/);
+
+    expect(errors.length).to.equal(1);
+    expect(errors[0]).to.match(/PINGFAIL/);
+    expect(errors[0]).to.match(/invalid literal/i);
   });
 
   it('does not ping duplicate records', async () => {

--- a/test/urlutil-test.js
+++ b/test/urlutil-test.js
@@ -51,6 +51,21 @@ describe('urlutil', () => {
     expect(urlutil.expand(url)).to.equal(url);
   });
 
+  it('throws invalid template errors', () => {
+    let err = null;
+    try {
+      const url = 'https://some/host/<showid>/<adid>/<pos>?IP={ip}';
+      expect(urlutil.expand(url, TEST_IMPRESSION())).to.equal(url);
+    } catch (e) {
+      err = e;
+    }
+    if (err) {
+      expect(err.message).to.match(/Invalid Literal "https:/);
+    } else {
+      expect.fail('should have thrown an error');
+    }
+  });
+
   it('gets the md5 digest for the agent', () => {
     let url = urlutil.expand('http://foo.bar/?ua={agentmd5}', TEST_IMPRESSION());
     expect(url).to.equal('http://foo.bar/?ua=da08af6021d3ec8b8d27558ca92c314e');


### PR DESCRIPTION
`urijs` _might_ throw an error if the template looks invalid.

The pingback url must contain a bracket `{}` to get past [here](https://github.com/PRX/analytics-ingest-lambda/blob/master/lib/urlutil.js#L25) ... then it will throw if it contains [any invalid chars](https://github.com/medialize/URI.js/blob/gh-pages/src/URITemplate.js#L368).

Just logger.error these and move on.