### PR TITLE
Feat/handle dovetail router log filter subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ The 4 lambdas functions are deployed via a Cloudformation stack in the [Infrastr
 
 # Docker
 
+To get started, first make sure you have the MaxMind env vars set up as
+these are needed for the docker build. Look for them in the staging
+site using AWS 'SSM':
+
+```
+aws ssm get-parameter --with-decryption --name /prx/test/analytics-ingest-lambda/MAXMIND_LICENSE_KEY
+```
+
 This repo is now dockerized! You'll need some read-only S3 credentials in your
 `.env` file for the `bin/getdatacenters.js` script to succeed during build:
 

--- a/index.js
+++ b/index.js
@@ -89,6 +89,6 @@ exports.handler = async (event) => {
     return `Inserted ${total} rows`;
   } catch(err) {
       clearTimeout(timer);
-      return logger.errors(err);
+      throw logger.errors(err);
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const zlib = require('zlib');
+const { promisify } = require('util');
 const logger = require('./lib/logger');
 const loadenv = require('./lib/loadenv');
 const timestamp = require('./lib/timestamp');
 const { BigqueryInputs, DynamoInputs, PingbackInputs, RedisInputs } = require('./lib/inputs');
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event) => {
   let records = [];
 
   // debug timeouts
@@ -20,7 +21,7 @@ exports.handler = (event, context, callback) => {
     logger.error(`Invalid event input: ${JSON.stringify(event)}`);
   } else {
     // concat in the log filter case: an event record contains a set of records.
-    records = [].concat.apply([], event.Records.map(r => {
+    records = [].concat.apply([], await Promise.all(event.Records.map(async r => {
       try {
         return JSON.parse(Buffer.from(r.kinesis.data, 'base64').toString('utf-8'));
       } catch (decodeErr) {
@@ -28,7 +29,7 @@ exports.handler = (event, context, callback) => {
           // it is coming from the dovetail-router log filter subscription.
           try{
               const buffer = Buffer.from(r.kinesis.data, 'base64');
-              const unzipped = zlib.gunzipSync(buffer)
+              const unzipped = await promisify(zlib.gunzip)(buffer)
               return JSON.parse(unzipped).logEvents.map(logLine => JSON.parse(logLine.message));
           }
           catch (decodeErr){
@@ -36,7 +37,7 @@ exports.handler = (event, context, callback) => {
             return null;
           }
       }
-    })).filter(r => {
+    }))).filter(r => {
       if (process.env.PROCESS_AFTER && r && r.timestamp) {
         const after = timestamp.toEpochSeconds(parseInt(process.env.PROCESS_AFTER));
         const time = timestamp.toEpochSeconds(r.timestamp);
@@ -54,38 +55,40 @@ exports.handler = (event, context, callback) => {
   // nothing to do
   if (records.length === 0) {
     clearTimeout(timer);
-    return callback();
+    return;
   }
 
-  loadenv.load(() => {
-    // figure out what type of records we process
-    let inputs;
-    if (process.env.REDIS_HOST) {
-      inputs = new RedisInputs(records);
-    } else if (process.env.PINGBACKS) {
-      inputs = new PingbackInputs(records);
-    } else if (process.env.DYNAMODB) {
-      inputs = new DynamoInputs(records);
-    } else {
-      inputs = new BigqueryInputs(records);
-    }
+  await new Promise((resolve, reject) => {
+    loadenv.load(() => {
+      resolve()
+    })
+  })
 
-    // complain very loudly about unrecognized input records
-    inputs.unrecognized.forEach(r => {
-      logger.error(`Unrecognized input record: ${JSON.stringify(r)}`);
-    });
+  // figure out what type of records we process
+  let inputs;
+  if (process.env.REDIS_HOST) {
+    inputs = new RedisInputs(records);
+  } else if (process.env.PINGBACKS) {
+    inputs = new PingbackInputs(records);
+  } else if (process.env.DYNAMODB) {
+    inputs = new DynamoInputs(records);
+  } else {
+    inputs = new BigqueryInputs(records);
+  }
 
-    // run inserts in parallel
-    inputs.insertAll().then(
-      results => {
-        clearTimeout(timer);
-        let total = results.reduce((acc, r) => acc + r.count, 0);
-        callback(null, `Inserted ${total} rows`);
-      },
-      err => {
-        clearTimeout(timer);
-        callback(logger.errors(err));
-      }
-    );
+  // complain very loudly about unrecognized input records
+  inputs.unrecognized.forEach(r => {
+    logger.error(`Unrecognized input record: ${JSON.stringify(r)}`);
   });
+
+  // run inserts in parallel
+  try{
+    const results = await inputs.insertAll();
+    clearTimeout(timer);
+    let total = results.reduce((acc, r) => acc + r.count, 0);
+    return `Inserted ${total} rows`;
+  } catch(err) {
+      clearTimeout(timer);
+      return logger.errors(err);
+  }
 };

--- a/lib/get-records.js
+++ b/lib/get-records.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const zlib = require('zlib');
+const { promisify } = require('util');
+const logger = require('./logger');
+
+function shallow_flatten(arr){
+  return [].concat.apply([], arr);
+}
+
+exports.getRecordsFromEvent = async function(event){
+  // flatten in the log filter case: an event record contains a set of records.
+  return shallow_flatten(await Promise.all(event.Records.map(async r => {
+    try {
+      return JSON.parse(Buffer.from(r.kinesis.data, 'base64').toString('utf-8'));
+    } catch (decodeErr) {
+      // In the case that our kinesis data is base64 + gzipped,
+      // it is coming from the dovetail-router log filter subscription.
+      try{
+        const buffer = Buffer.from(r.kinesis.data, 'base64');
+        const unzipped = await promisify(zlib.gunzip)(buffer);
+        return JSON.parse(unzipped).logEvents.map(logLine => JSON.parse(logLine.message));
+      }
+      catch (decodeErr){
+        logger.error(`Invalid record input: ${decodeErr} ${JSON.stringify(r)}`);
+        return null;
+      }
+    }
+  })));
+}

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -78,6 +78,9 @@ module.exports = class DovetailImpressions {
         campaign_id:      imp.campaignId,
         creative_id:      imp.creativeId,
         flight_id:        imp.flightId,
+        target_path:      imp.targetPath || null,
+        zone_name:        imp.zoneName || null,
+        placements_key:   imp.placementsKey || null,
         is_duplicate:     info.isDuplicate,
         cause:            info.cause
       }

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -8,12 +8,8 @@ const kinesis   = require('../lib/kinesis');
 const logger    = require('../lib/logger');
 const index     = require('../index');
 
-function handler(event) {
-  return new Promise((resolve, reject) => {
-    index.handler(event, {}, (err, res) => {
-      err ? reject(err) : resolve(res);
-    });
-  });
+async function handler(event) {
+  return await index.handler(event);
 }
 
 describe('handler', () => {

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -299,4 +299,11 @@ describe('handler', () => {
     expect(all[3].length).to.equal(0);
   });
 
-});
+  it('handles log subscription filter input', async () => {
+    const result = await handler({"Records": [{"kinesis": {"data": "H4sIAAg0L14AA9VSO0/DMBjc+ysqi7EoftvpFonQBRaSrUHIadwoUl5KXCpU9b/zOaUtMHVDeIit3Pl8d/ZhNoeBGjuOprTpR2/Rco4eojR6e46TJFrFaHGidPvWDh7UlAkOH0IoO4N1V66Gbtd7PDD7MahNkxcmqJp+AOmqa++BUlZt+W1H4gZrGr+FYooDTAKqgvXdU5TGSfq6lZoWmJGc6JBTlWvQUybkYlvkhhN8Fhp3+bgZqt7BIY9V7ewwguR6AifCS9e5aLMBG2j6+Xp1EL/b1v2kHy6riVQV3h8TlGlOseBScg2T4lhhpvxMmMaKEKklDrlSTAkqYQGJ9NnjRc1VULQzje+JCI0JFxANivzF+7oOf/QhQ81YZmiZoWuZGVpkyIEUFDpB89bu66q1GTpmLbqIHRe35wqpFNLfKgbjWnIlJVOaEUolx5CWK6GwlJKGhN2ai/+vXPzPc50e6Ow4+wT7VNt9mAMAAA=="}}]});
+    expect(result).to.match(/inserted 0/i);
+    expect(errs.length).to.equal(3);
+    expect(errs[0]).to.match(/Unrecognized input record/i);
+    expect(errs[0]).to.match(/"msg":"impression"/i);
+    });
+  });

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -298,11 +298,31 @@ describe('handler', () => {
     expect(all[3].length).to.equal(0);
   });
 
-  it('handles log subscription filter input', async () => {
+  it('handles unknown input records parsed from the log subscription filter style kinesis input', async () => {
+    /* unknown records in the format of
+    {
+        "id": "35238420546692656231100808647663783122640070475706662913",
+        "timestamp": 1580145427114,
+        "message": "{\"msg\":\"impression\",\"testing\":\" newline\"}\n"
+    } */
+
     const result = await handler({"Records": [{"kinesis": {"data": "H4sIAAg0L14AA9VSO0/DMBjc+ysqi7EoftvpFonQBRaSrUHIadwoUl5KXCpU9b/zOaUtMHVDeIit3Pl8d/ZhNoeBGjuOprTpR2/Rco4eojR6e46TJFrFaHGidPvWDh7UlAkOH0IoO4N1V66Gbtd7PDD7MahNkxcmqJp+AOmqa++BUlZt+W1H4gZrGr+FYooDTAKqgvXdU5TGSfq6lZoWmJGc6JBTlWvQUybkYlvkhhN8Fhp3+bgZqt7BIY9V7ewwguR6AifCS9e5aLMBG2j6+Xp1EL/b1v2kHy6riVQV3h8TlGlOseBScg2T4lhhpvxMmMaKEKklDrlSTAkqYQGJ9NnjRc1VULQzje+JCI0JFxANivzF+7oOf/QhQ81YZmiZoWuZGVpkyIEUFDpB89bu66q1GTpmLbqIHRe35wqpFNLfKgbjWnIlJVOaEUolx5CWK6GwlJKGhN2ai/+vXPzPc50e6Ow4+wT7VNt9mAMAAA=="}}]});
     expect(result).to.match(/inserted 0/i);
     expect(errs.length).to.equal(3);
     expect(errs[0]).to.match(/Unrecognized input record/i);
     expect(errs[0]).to.match(/"msg":"impression"/i);
-    });
   });
+
+  it('handles dt-router antebytes input records parsed from the log subscription filter style kinesis input', async () => {
+    /* records in the format of
+    {
+        "id": "35238420546692656231100808647663783122640070475706662913",
+        "timestamp": 1580145427114,
+        "message": "{\"msg\":\"impression\",\"type\":\"antebytes\" ..... }\n"
+    } */
+    sinon.stub(dynamo, 'write').callsFake(async (recs) => recs.length);
+    process.env.DYNAMODB = 'true';
+    const result = await handler({"Records": [{"kinesis": {"data": "H4sIAAMrN14AA41UW3OiSBR+z6+gqH2YqQpCN80t++RGzTiOM050czVFNXDArgBNoNVxUvnv2zTG6L7sWpbgd75z+c453a9nmvzoBTQNzWCxq0C/0PRBf9EPp8P5vH811M87Ct+WULdGH9sOkT8IYfvdmPPsqubrqrWbdNuYOS2ihJqsqGoZmvHSkJSMldmRx1zUQIvWBVvYMi1kYs98/ONbfzGcL55S18eJZaMI+QHBXuTLeB4NiJMmESXIeg/UrKMmrlklZJIRywXUjQz5qIyKcM256MexLENX4NNHBcMNlOKU/np4UySWtPXZDrZ9gi2HuC7x5cMjlmfZXvtEtm95CLm+awXE82zPwa58kYr89xoP0QSTjRa0aPuEHN9CxJHSZCP/xduPo039ulReS/1iqdpkWFh+F8i+IPYFxj3sOA9L/Xyp57CBXNFYmXIFFU3WAYcpKDjmZcrqAhJpTGnegMQSlsnKFHtbNpuf2583sxHkd8XDfbh5odMfzctuNbDvy1E53d6Wi+f1HTHGKlwiNyPntI0mi6XJJV+XbaRynedtNrpu4OMvawbrKmcxFfCe/k3CKUAC9bBiDU86sXGMk8gnsUH91DUIIq5BcRIYCcQupuAQxyUqf+c640lMlQKM7PNjzY3EHlVl4+S4rKKiLCtPsZNSY7megm3gmJLmLFuJY+RU0B6schpD0S7XBHZKjth2M2kga/EPqqB1BmJGxeoD+81L+E73UxdyMGEnMpSaQrTU357agbNGQHnatOkXw7WJYL/ocLeKrtiGe/YkmTe3N7PJeLB1jfn96vn6u1WH025p9jGUIKkOBREOwDJs7GGDRMgxArndBgGgAbYxJAEovxoKLqCfdUpkXv6b5Tk1nZ6lfZrSmJWCN6s/tXEpINckoP2Ya3caskJEQuez1q+qHG4hmjBhOrbXs13t0+TLYvrtXMvZM2hXED/zz9rlquYFmF7Qs3q2PPo939fmNKU123sdFTOuVCUIe5Js9dCR6RpSqGuoFWGPv6xlW/9es074CAxx++svP6sH0c1D0+/3L78eE8P/4h1OtqS1J9v1sGvh1iCvVOVKZSuinRym4q/r7qyaclvN/7PqpuWEQRDOoI5l08MRrzMu5Ox6RWWbciP0ww3y1t1yZ29n/wDBjpD43QUAAA=="}}]})
+    expect(result).to.match(/inserted 1/i);
+  })
+});

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -72,7 +72,7 @@ describe('handler', () => {
   it('handles bigquery records', async () => {
     const inserted = {};
     sinon.stub(bigquery, 'insert').callsFake((ds, tbl, rows) => {
-      inserted[tbl] = rows;
+      inserted[tbl] = rows.sort((a, b)=> a.insertId < b.insertId ? -1 : 1 );
       return Promise.resolve(rows.length);
     });
 

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -197,17 +197,17 @@ describe('handler', () => {
     process.env.DYNAMODB = 'true';
 
     const result = await handler(event);
-    expect(result).to.match(/inserted 3/i);
+    expect(result).to.match(/inserted 4/i);
     expect(infos.length).to.equal(2);
     expect(warns.length).to.equal(1);
     expect(errs.length).to.equal(0);
-    expect(infos[0].msg).to.match(/inserted 2 rows into dynamodb/i);
-    expect(infos[0].meta).to.contain({dest: 'dynamodb', rows: 2});
+    expect(infos[0].msg).to.match(/inserted 3 rows into dynamodb/i);
+    expect(infos[0].meta).to.contain({dest: 'dynamodb', rows: 3});
     expect(infos[1].msg).to.match(/inserted 1 rows into kinesis/i);
     expect(infos[1].meta).to.contain({dest: 'kinesis:foobar_stream', rows: 1});
     expect(warns[0]).to.match(/missing segment listener-episode-3.the-digest.4/i);
 
-    expect(dynamo.write.args[0][0].length).to.equal(2);
+    expect(dynamo.write.args[0][0].length).to.equal(3);
     expect(dynamo.write.args[0][0][0].type).to.equal('antebytes');
     expect(dynamo.write.args[0][0][0].any).to.equal('thing');
     expect(dynamo.write.args[0][0][0].id).to.equal('listener-episode-4.the-digest');
@@ -218,6 +218,9 @@ describe('handler', () => {
     expect(dynamo.write.args[0][0][1].id).to.equal('listener-episode-5.the-digest');
     expect(dynamo.write.args[0][0][1].listenerEpisode).to.be.undefined;
     expect(dynamo.write.args[0][0][1].digest).to.be.undefined;
+    expect(dynamo.write.args[0][0][2].type).to.equal('antebytes');
+    expect(dynamo.write.args[0][0][2].time).to.equal('2020-02-02T13:43:22.255Z');
+    expect(dynamo.write.args[0][0][2].msg).to.equal('impression');
 
     expect(kinesis.put.args[0][0].length).to.equal(1);
     expect(kinesis.put.args[0][0][0].type).to.equal('postbytes');

--- a/test/inputs-ante-bytes-test.js
+++ b/test/inputs-ante-bytes-test.js
@@ -15,6 +15,55 @@ describe('ante-bytes', () => {
     expect(bytes.check({type: 'antebytespreview'})).to.be.true;
   });
 
+  it('recognizes and formats the antebytes record from dt-router', () => {
+
+    const dtAntebytesRecord = {
+      "time": "2020-01-23T12:10:43.177Z",
+      "level": "info",
+      "msg": "impression",
+      "confirmed": true,
+      "digest": "digest1",
+      "download": {
+        "adCount": 1,
+        "cause": "something",
+        "isDuplicate": false
+      },
+      "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+      "feederPodcast": 213,
+      "impressions": [
+        {
+          "isDuplicate": false,
+          "placementsKey": "two",
+          "segment": 2,
+          "targetPath": ":Some-target",
+          "zoneName": "test_feeder_pre_1"
+        }
+      ],
+      "listenerEpisode": "le1",
+      "type": "antebytes",
+    }
+    const bytes = new AnteBytes();
+    expect(bytes.check(dtAntebytesRecord)).to.be.true;
+    const formatted = bytes.format(dtAntebytesRecord);
+    expect(formatted).to.eql({
+      id: 'le1.digest1',
+      feederEpisode: "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+      feederPodcast: 213,
+      confirmed: true,
+      download: {adCount: 1},
+      impressions: [{
+          segment: 2,
+          placementsKey: "two",
+          targetPath: ":Some-target",
+          zoneName: "test_feeder_pre_1"}
+      ],
+      level: "info",
+      msg: "impression",
+      time: "2020-01-23T12:10:43.177Z",
+      type: "antebytes",
+    });
+  });
+
   it('formats dynamodb records', () => {
     const bytes = new AnteBytes();
     const formatted = bytes.format({

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -43,7 +43,8 @@ describe('dovetail-impressions', () => {
       'digest', 'listener_session',
       'is_confirmed', 'is_bytes', 'segment',
       'ad_id', 'campaign_id', 'creative_id', 'flight_id',
-      'is_duplicate', 'cause'
+      'is_duplicate', 'cause',
+      'placements_key', 'target_path', 'zone_name',
     );
     expect(format1.json.timestamp).to.equal(1490827132);
     expect(format1.json.listener_session.length).to.be.above(10);
@@ -85,13 +86,14 @@ describe('dovetail-impressions', () => {
       {type: 'combined', listenerEpisode: 'listen2', timestamp: 1490827132999, impressions: [{adId: 1}, {adId: 2}]},
       {type: 'combined', listenerEpisode: 'listen3', timestamp: 1490837132, impressions: [{isDuplicate: true, adId: 3}]},
       {type: 'postbytespreview', listenerEpisode: 'listen4', timestamp: 1490837132, impressions: [{adId: 4}]},
-      {type: 'postbytes', listenerEpisode: 'listen5', timestamp: 1490827132999, impressions: [{adId: 5}]}
+      {type: 'postbytes', listenerEpisode: 'listen5', timestamp: 1490827132999, impressions: [{adId: 5}]},
+      {type: 'combined', listenerEpisode: 'listen6', timestamp: 1490837132, impressions: [{targetPath: ':Some-target', zoneName: 'some_pre1', placementsKey: '2' }]},
     ]);
     return impression2.insert().then(result => {
       expect(result.length).to.equal(2);
 
       expect(result[0].dest).to.equal('dt_impressions');
-      expect(result[0].count).to.equal(4);
+      expect(result[0].count).to.equal(5);
       expect(inserts['dt_impressions'][0].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][0].json.ad_id).to.equal(1);
       expect(inserts['dt_impressions'][0].json.is_bytes).to.equal(false);
@@ -104,6 +106,9 @@ describe('dovetail-impressions', () => {
       expect(inserts['dt_impressions'][3].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][3].json.ad_id).to.equal(5);
       expect(inserts['dt_impressions'][3].json.is_bytes).to.equal(true);
+      expect(inserts['dt_impressions'][4].json.target_path).to.equal(':Some-target');
+      expect(inserts['dt_impressions'][4].json.zone_name).to.equal('some_pre1');
+      expect(inserts['dt_impressions'][4].json.placements_key).to.equal('2');
 
       expect(result[1].dest).to.equal('dt_impressions_preview');
       expect(result[1].count).to.equal(1);

--- a/test/integration/runner.js
+++ b/test/integration/runner.js
@@ -3,14 +3,18 @@
 if (!process.env.BQ_CLIENT_EMAIL) {
   require('dotenv').config();
 }
-const { buildEvent } = require('../support/build');
+const { buildMixedStyleEvent } = require('../support/build');
 const handler = require('../../index').handler;
 
 // bigquery does not like timestamps more than 7 days in the past
-const testRecords = require('../support/test-runner-records').map(rec => {
+const testRecordSets = require('../support/test-runner-records');
+
+const testInputStyleRecords = testRecordSets.inputStyleRecords.map(rec => {
   return {...rec, timestamp: new Date().getTime()};
 }).filter(r => r.type !== 'foo')
-const testEvent = buildEvent(testRecords);
+
+const testEvent = buildMixedStyleEvent(testInputStyleRecords,
+  testRecordSets.kinesisEventStyleRecords);
 
 // decode pingback settings
 if (process.env.REDIS_HOST && process.env.REDIS_HOST !== '0') {

--- a/test/support/build.js
+++ b/test/support/build.js
@@ -17,3 +17,14 @@ exports.buildEvent = (records) => {
     Records: records.map(r => exports.buildRecord(r))
   };
 };
+
+// build an event from input style and kinesis style recs
+exports.buildMixedStyleEvent = (inputStyleRecords, kinesisStyleRecords) => {
+  const res= {
+    // Here we process the input style records, turning them into kinesis style
+    // recs.
+    // Just pass the kinesisStyleRecords through.
+    Records: inputStyleRecords.map(r => exports.buildRecord(r)).concat(kinesisStyleRecords)
+  };
+  return res
+};

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -129,5 +129,43 @@
     "remoteAgent": "some-user-agent",
     "remoteIp": "127.0.0.1",
     "remoteReferrer": "https://www.prx.org/technology/"
+  },
+  {
+    "time": "2020-02-02T13:43:22.255Z",
+    "level": "info",
+    "msg": "impression",
+    "confirmed": false,
+    "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
+    "download": {
+      "adCount": null,
+      "cause": null,
+      "isDuplicate": false
+    },
+    "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+    "feederPodcast": 213,
+    "impressions": [
+      {
+        "adId": null,
+        "campaignId": null,
+        "cause": null,
+        "creativeId": null,
+        "flightId": null,
+        "isDuplicate": null,
+        "placementsKey": "two",
+        "segment": null,
+        "targetPath": null,
+        "zoneName": "test_feeder_pre_1"
+      }
+    ],
+    "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
+    "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
+    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+    "remoteIp": "127.0.0.1",
+    "remoteReferrer": "",
+    "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
+    "request_id": "Fe-tWxB8grDbVZsAAACJ",
+    "timestamp": 1580672602,
+    "type": "antebytes",
+    "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
   }
 ]

--- a/test/support/test-runner-records.json
+++ b/test/support/test-runner-records.json
@@ -1,289 +1,277 @@
-[
-  {
-    "type": "combined",
-    "download": {
-      "isDuplicate": false,
-      "cause": null,
-      "adCount": 2
-    },
-    "impressions": [
-      {
-        "segment": 0,
-        "adId": 12,
-        "campaignId": 34,
-        "creativeId": 56,
-        "flightId": 78,
-        "isDuplicate": false,
-        "cause": null,
-        "pings": ["http://dovetail.prxu.org"]
-      },
-      {
-        "segment": 2,
-        "adId": 98,
-        "campaignId": 34,
-        "creativeId": 56,
-        "flightId": 78,
-        "isDuplicate": true,
-        "cause": "something",
-        "pings": ["https://foo.bar/this/should/not/fire"]
-      }
+{
+    "inputStyleRecords": [
+        {
+            "type": "combined",
+            "download": {
+                "isDuplicate": false,
+                "cause": null,
+                "adCount": 2
+            },
+            "impressions": [
+                {
+                    "segment": 0,
+                    "adId": 12,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": false,
+                    "cause": null,
+                    "pings": [
+                        "http://dovetail.prxu.org"
+                    ]
+                },
+                {
+                    "segment": 2,
+                    "adId": 98,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": true,
+                    "cause": "something",
+                    "pings": [
+                        "https://foo.bar/this/should/not/fire"
+                    ]
+                }
+            ],
+            "digest": "the-digest",
+            "feederPodcast": 1234,
+            "feederEpisode": "1234-5678",
+            "listenerId": "some-listener-id",
+            "listenerEpisode": "listener-episode-1",
+            "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
+            "remoteIp": " 50.21.204.248, 127.0.0.1",
+            "remoteReferrer": "https://www.prx.org/technology/",
+            "timestamp": 1487703699,
+            "url": "/1234/1234-5678/filename.mp3?foo=bar"
+        },
+        {
+            "type": "postbytes",
+            "impressions": [
+                {
+                    "segment": 0,
+                    "adId": 76,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": false,
+                    "cause": null,
+                    "pings": [
+                        "https://dovetail.prxu.org/ping",
+                        "https://dovetail.prxu.org/ping{?uuid}",
+                        "https://dovetail.prxu.org/{randomint}"
+                    ]
+                }
+            ],
+            "confirmed": true,
+            "digest": "the-digest",
+            "feederPodcast": 1234,
+            "feederEpisode": "1234-5678",
+            "listenerId": "some-listener-id",
+            "listenerEpisode": "listener-episode-2",
+            "remoteAgent": "some agent string",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "",
+            "timestamp": 1487803699,
+            "url": "/1234/1234-5678/filename.mp3?foo=bar"
+        },
+        {
+            "type": "postbytespreview",
+            "download": {
+                "isDuplicate": false,
+                "cause": null,
+                "adCount": 9
+            },
+            "impressions": [
+                {
+                    "segment": 2,
+                    "adId": 123,
+                    "campaignId": 456,
+                    "creativeId": 789,
+                    "flightId": 101112,
+                    "isDuplicate": false,
+                    "cause": null,
+                    "pings": [
+                        "https://dovetail.prxu.org/ping{?uuid}"
+                    ]
+                }
+            ],
+            "digest": "the-digest",
+            "feederPodcast": 1234,
+            "feederEpisode": "1234-5678",
+            "listenerId": "some-listener-id",
+            "listenerEpisode": "listener-episode-9",
+            "remoteAgent": "some agent string",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "",
+            "timestamp": 1487803699,
+            "url": "/1234/1234-5678/filename.mp3?foo=bar"
+        },
+        {
+            "type": "bytes",
+            "timestamp": 1539287413617,
+            "listenerEpisode": "listener-episode-3",
+            "digest": "the-digest",
+            "bytes": 104820,
+            "seconds": 2.5858585858,
+            "percent": 0.582747737
+        },
+        {
+            "type": "segmentbytes",
+            "timestamp": 1539287527,
+            "listenerEpisode": "listener-episode-3",
+            "digest": "the-digest",
+            "segment": 1
+        },
+        {
+            "type": "segmentbytes",
+            "timestamp": 1539287527,
+            "listenerEpisode": "listener-episode-3",
+            "digest": "the-digest",
+            "segment": 4
+        },
+        {
+            "type": "antebytes",
+            "download": {
+                "isDuplicate": false,
+                "cause": null,
+                "adCount": 4
+            },
+            "impressions": [
+                {
+                    "segment": 1,
+                    "adId": 76,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": false,
+                    "cause": null,
+                    "pings": [
+                        "https://dovetail.prxu.org/ping{?uuid}"
+                    ]
+                },
+                {
+                    "segment": 2,
+                    "adId": 123,
+                    "campaignId": 456,
+                    "creativeId": 789,
+                    "flightId": 1011,
+                    "isDuplicate": false,
+                    "cause": null
+                }
+            ],
+            "digest": "the-digest",
+            "feederPodcast": 1234,
+            "feederEpisode": "1234-5678",
+            "listenerId": "some-listener-id",
+            "listenerEpisode": "listener-episode-3",
+            "remoteAgent": "some agent string",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "",
+            "timestamp": 1487803699,
+            "url": "/1234/1234-5678/filename.mp3?foo=bar"
+        },
+        {
+            "type": "antebytespreview",
+            "download": {
+                "isDuplicate": false,
+                "cause": null,
+                "adCount": 1
+            },
+            "impressions": [],
+            "digest": "the-digest",
+            "feederPodcast": 1234,
+            "feederEpisode": "1234-5678",
+            "listenerId": "some-listener-id",
+            "listenerEpisode": "listener-episode-4",
+            "remoteAgent": "some agent string",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "",
+            "timestamp": 1487803699,
+            "url": "/1234/1234-5678/filename.mp3?foo=bar"
+        },
+        {
+            "type": "pixel",
+            "destination": "pixels",
+            "timestamp": 1490827132999,
+            "key": "test-runner-records1",
+            "canonical": "https://www.prx.org/url1",
+            "remoteAgent": "some-user-agent",
+            "remoteIp": "50.21.204.248",
+            "remoteReferrer": "https://www.prx.org/technology/",
+            "userId": "my-explicit-user-id"
+        },
+        {
+            "type": "pixel",
+            "destination": "pixels",
+            "timestamp": 1490827132999,
+            "key": "test-runner-records1",
+            "canonical": "https://www.prx.org/url1",
+            "remoteAgent": "some-other-agent",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "https://www.prx.org/technology/"
+        },
+        {
+            "time": "2020-02-02T13:43:22.255Z",
+            "level": "info",
+            "msg": "impression",
+            "confirmed": false,
+            "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
+            "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+            "feederPodcast": 213,
+            "download": {
+                "isDuplicate": false,
+                "cause": null,
+                "adCount": 2
+            },
+            "impressions": [
+                {
+                    "segment": 0,
+                    "adId": 12,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": false,
+                    "cause": null,
+                    "pings": [
+                        "http://dovetail.prxu.org"
+                    ],
+                    "targetPath": ":",
+                    "zoneName": "test_feeder_pre_1"
+                },
+                {
+                    "segment": 2,
+                    "adId": 98,
+                    "campaignId": 34,
+                    "creativeId": 56,
+                    "flightId": 78,
+                    "isDuplicate": true,
+                    "cause": "something",
+                    "pings": [
+                        "https://foo.bar/this/should/not/fire"
+                    ],
+                    "targetPath": ":Country-US",
+                    "zoneName": "test_feeder_pre_2"
+                }
+            ],
+            "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
+            "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
+            "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+            "remoteIp": "127.0.0.1",
+            "remoteReferrer": "",
+            "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
+            "request_id": "Fe-tWxB8grDbVZsAAACJ",
+            "timestamp": 1580672602,
+            "type": "combined",
+            "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
+        }
     ],
-    "digest": "the-digest",
-    "feederPodcast": 1234,
-    "feederEpisode": "1234-5678",
-    "listenerId": "some-listener-id",
-    "listenerEpisode": "listener-episode-1",
-    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
-    "remoteIp": " 50.21.204.248, 127.0.0.1",
-    "remoteReferrer": "https://www.prx.org/technology/",
-    "timestamp": 1487703699,
-    "url": "/1234/1234-5678/filename.mp3?foo=bar"
-  },
-  {
-    "type": "postbytes",
-    "impressions": [{
-      "segment": 0,
-      "adId": 76,
-      "campaignId": 34,
-      "creativeId": 56,
-      "flightId": 78,
-      "isDuplicate": false,
-      "cause": null,
-      "pings": [
-        "https://dovetail.prxu.org/ping",
-        "https://dovetail.prxu.org/ping{?uuid}",
-        "https://dovetail.prxu.org/{randomint}"
-      ]
-    }],
-    "confirmed": true,
-    "digest": "the-digest",
-    "feederPodcast": 1234,
-    "feederEpisode": "1234-5678",
-    "listenerId": "some-listener-id",
-    "listenerEpisode": "listener-episode-2",
-    "remoteAgent": "some agent string",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "timestamp": 1487803699,
-    "url": "/1234/1234-5678/filename.mp3?foo=bar"
-  },
-  {
-    "type": "postbytespreview",
-    "download": {
-      "isDuplicate": false,
-      "cause": null,
-      "adCount": 9
-    },
-    "impressions": [{
-      "segment": 2,
-      "adId": 123,
-      "campaignId": 456,
-      "creativeId": 789,
-      "flightId": 101112,
-      "isDuplicate": false,
-      "cause": null,
-      "pings": [
-        "https://dovetail.prxu.org/ping{?uuid}"
-      ]
-    }],
-    "digest": "the-digest",
-    "feederPodcast": 1234,
-    "feederEpisode": "1234-5678",
-    "listenerId": "some-listener-id",
-    "listenerEpisode": "listener-episode-9",
-    "remoteAgent": "some agent string",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "timestamp": 1487803699,
-    "url": "/1234/1234-5678/filename.mp3?foo=bar"
-  },
-  {
-    "type": "bytes",
-    "timestamp": 1539287413617,
-    "listenerEpisode": "listener-episode-3",
-    "digest": "the-digest",
-    "bytes": 104820,
-    "seconds": 2.5858585858,
-    "percent": 0.582747737
-  },
-  {
-    "type": "segmentbytes",
-    "timestamp": 1539287527,
-    "listenerEpisode": "listener-episode-3",
-    "digest": "the-digest",
-    "segment": 1
-  },
-  {
-    "type": "segmentbytes",
-    "timestamp": 1539287527,
-    "listenerEpisode": "listener-episode-3",
-    "digest": "the-digest",
-    "segment": 4
-  },
-  {
-    "type": "antebytes",
-    "download": {
-      "isDuplicate": false,
-      "cause": null,
-      "adCount": 4
-    },
-    "impressions": [{
-      "segment": 1,
-      "adId": 76,
-      "campaignId": 34,
-      "creativeId": 56,
-      "flightId": 78,
-      "isDuplicate": false,
-      "cause": null,
-      "pings": [
-        "https://dovetail.prxu.org/ping{?uuid}"
-      ]
-    },{
-      "segment": 2,
-      "adId": 123,
-      "campaignId": 456,
-      "creativeId": 789,
-      "flightId": 1011,
-      "isDuplicate": false,
-      "cause": null
-    }],
-    "digest": "the-digest",
-    "feederPodcast": 1234,
-    "feederEpisode": "1234-5678",
-    "listenerId": "some-listener-id",
-    "listenerEpisode": "listener-episode-3",
-    "remoteAgent": "some agent string",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "timestamp": 1487803699,
-    "url": "/1234/1234-5678/filename.mp3?foo=bar"
-  },
-  {
-    "type": "antebytespreview",
-    "download": {
-      "isDuplicate": false,
-      "cause": null,
-      "adCount": 1
-    },
-    "impressions": [],
-    "digest": "the-digest",
-    "feederPodcast": 1234,
-    "feederEpisode": "1234-5678",
-    "listenerId": "some-listener-id",
-    "listenerEpisode": "listener-episode-4",
-    "remoteAgent": "some agent string",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "timestamp": 1487803699,
-    "url": "/1234/1234-5678/filename.mp3?foo=bar"
-  },
-  {
-    "type": "pixel",
-    "destination": "pixels",
-    "timestamp": 1490827132999,
-    "key": "test-runner-records1",
-    "canonical": "https://www.prx.org/url1",
-    "remoteAgent": "some-user-agent",
-    "remoteIp": "50.21.204.248",
-    "remoteReferrer": "https://www.prx.org/technology/",
-    "userId": "my-explicit-user-id"
-  },
-  {
-    "type": "pixel",
-    "destination": "pixels",
-    "timestamp": 1490827132999,
-    "key": "test-runner-records1",
-    "canonical": "https://www.prx.org/url1",
-    "remoteAgent": "some-other-agent",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "https://www.prx.org/technology/"
-  },
-  {
-    "time": "2020-02-02T13:43:22.255Z",
-    "level": "info",
-    "msg": "impression",
-    "confirmed": false,
-    "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
-    "download": {
-      "adCount": null,
-      "cause": null,
-      "isDuplicate": false
-    },
-    "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
-    "feederPodcast": 213,
-    "impressions": [
-      {
-        "adId": null,
-        "campaignId": null,
-        "cause": null,
-        "creativeId": null,
-        "flightId": null,
-        "isDuplicate": null,
-        "placementsKey": "two",
-        "segment": null,
-        "targetPath": null,
-        "zoneName": "test_feeder_pre_1"
-      }
-    ],
-    "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
-    "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
-    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
-    "request_id": "Fe-tWxB8grDbVZsAAACJ",
-    "timestamp": 1580672602,
-    "type": "antebytes",
-    "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
-  },
-  {
-    "time": "2020-02-02T13:43:22.255Z",
-    "level": "info",
-    "msg": "impression",
-    "confirmed": false,
-    "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
-    "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
-    "feederPodcast": 213,
-    "download": {
-      "isDuplicate": false,
-      "cause": null,
-      "adCount": 2
-    },
-    "impressions": [
-      {
-        "segment": 0,
-        "adId": 12,
-        "campaignId": 34,
-        "creativeId": 56,
-        "flightId": 78,
-        "isDuplicate": false,
-        "cause": null,
-        "pings": ["http://dovetail.prxu.org"],
-        "targetPath": ":",
-        "zoneName": "test_feeder_pre_1"
-      },
-      {
-        "segment": 2,
-        "adId": 98,
-        "campaignId": 34,
-        "creativeId": 56,
-        "flightId": 78,
-        "isDuplicate": true,
-        "cause": "something",
-        "pings": ["https://foo.bar/this/should/not/fire"],
-        "targetPath": ":Country-US",
-        "zoneName": "test_feeder_pre_2"
-      }
-    ],
-    "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
-    "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
-    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
-    "remoteIp": "127.0.0.1",
-    "remoteReferrer": "",
-    "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
-    "request_id": "Fe-tWxB8grDbVZsAAACJ",
-    "timestamp": 1580672602,
-    "type": "combined",
-    "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
-  }
-]
+    "kinesisEventStyleRecords": [
+        {
+            "eventSource": "aws:kinesis",
+            "eventVersion": "1.0",
+            "kinesis": {
+                "data": "H4sIAOKaOF4AA21UXW+bShB9z6/govvQSsHAsnzlPlmNk0auWzd2m6RxhBYY41WAJbDY143y3++w2I5dXcsy+MyZjzMzu69nGn70ApqGZTDfVqBfaPrlcD6MJqPZbHg90s97itiUUHfGgDguxR/bJs7emIvsuhZt1dlNtmnMnBVxykxeVDWG5qI0kJLxMjvymMkaWNG5EItYpmWbxDcf//4ynI9m86elF5DUcuzYDkJK/DjAeD4LqbtMY0Ztax+oaeMmqXklMckVzyXUDYZ8VEZFuBVCDpMEy9AV+PRewWgNpTylvx7eFImnXX2OS5yAEsulnkcDfPjU8i3H7562E1i+bXuBZ4XU9x3fJR6+oKJgX+MhmuTYaMmKrk+2G1g2dVEaNvIP3m4cXerXhfJa6BcL1SbDIvid284FdS4IGRDX/bXQzxd6DmvIFY2XS6Ggosl64DAFBSeiXPK6gBSNS5Y3gFjKM6xMsTdls/6++f5zegX5ffHrIVq/sMm35mW7unQeyqtysrkr58/tPTVuVLgUNyMXrIuGxbL0k2jLLlLZ5nmXjbUNvP/lzWVb5TxhEvbp3xBeAqRQjyreiLQXmyQkjQOaGCxYega1qWcwkoZGColHGLjU9ajK37tORZowpYDYzvmx5gaxR1XZTXpcVlExnpWn2EmpCa6n5Gs4pixznq3kMXIqaAdWOUug6JZrDFslR276mTSQdfg7VbI6AzllcvWO/RYlfGW7qUscTNSLjFBTZC/0t6du4LyRUJ42bfLZ8Bwq+b9stF3F13wtfGeczpq7n9PxzeXGM2YPq+fbr1YdTfql2cVQglCdHcYkBMtwiE8MGtuuEeJ2GxSAhcQhkIag/GoohIRh1ivBvOI3z3NmugNL+zBhCS+laFb/aDelhFxDQPs20+4124psGrkftWFV5XAH8ZhL03X8geNpH8af55Mv51rOn0G7huRZfNQ+rWpRgOmHA2vg4NEfBIE2Y0tW853XUTE3laqE0sH+e2S8hSXUNdSKssNfWmzsj5b30mO8JZLVX8e26H9MhxOMlu4Eez7xLNIZ8OpUbIaS4y0OTfHbuj+TJm6l2aAYo8WMpuVGYRhNoU6wg9GVqDMhcRCDonJMHK9+uA7e+ivr7O3sP5jtmEiqBQAA"
+            }
+        }
+    ]
+}

--- a/test/support/test-runner-records.json
+++ b/test/support/test-runner-records.json
@@ -197,5 +197,93 @@
     "remoteAgent": "some-other-agent",
     "remoteIp": "127.0.0.1",
     "remoteReferrer": "https://www.prx.org/technology/"
+  },
+  {
+    "time": "2020-02-02T13:43:22.255Z",
+    "level": "info",
+    "msg": "impression",
+    "confirmed": false,
+    "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
+    "download": {
+      "adCount": null,
+      "cause": null,
+      "isDuplicate": false
+    },
+    "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+    "feederPodcast": 213,
+    "impressions": [
+      {
+        "adId": null,
+        "campaignId": null,
+        "cause": null,
+        "creativeId": null,
+        "flightId": null,
+        "isDuplicate": null,
+        "placementsKey": "two",
+        "segment": null,
+        "targetPath": null,
+        "zoneName": "test_feeder_pre_1"
+      }
+    ],
+    "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
+    "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
+    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+    "remoteIp": "127.0.0.1",
+    "remoteReferrer": "",
+    "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
+    "request_id": "Fe-tWxB8grDbVZsAAACJ",
+    "timestamp": 1580672602,
+    "type": "antebytes",
+    "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
+  },
+  {
+    "time": "2020-02-02T13:43:22.255Z",
+    "level": "info",
+    "msg": "impression",
+    "confirmed": false,
+    "digest": "wnsvQwQVPFelXmZY_vqaMOsqyhD3YnFnMwWnTkuX4-I",
+    "feederEpisode": "cc2db84c-a8f6-4146-a2d9-dec62ae54564",
+    "feederPodcast": 213,
+    "download": {
+      "isDuplicate": false,
+      "cause": null,
+      "adCount": 2
+    },
+    "impressions": [
+      {
+        "segment": 0,
+        "adId": 12,
+        "campaignId": 34,
+        "creativeId": 56,
+        "flightId": 78,
+        "isDuplicate": false,
+        "cause": null,
+        "pings": ["http://dovetail.prxu.org"],
+        "targetPath": ":",
+        "zoneName": "test_feeder_pre_1"
+      },
+      {
+        "segment": 2,
+        "adId": 98,
+        "campaignId": 34,
+        "creativeId": 56,
+        "flightId": 78,
+        "isDuplicate": true,
+        "cause": "something",
+        "pings": ["https://foo.bar/this/should/not/fire"],
+        "targetPath": ":Country-US",
+        "zoneName": "test_feeder_pre_2"
+      }
+    ],
+    "listenerEpisode": "MH-634tixaEyhbGivo73KdSsWVPKIDw6-SYhkRN0r_M",
+    "listenerId": "f19b29e0-3272-4b15-9807-4eea9232ed9e",
+    "remoteAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+    "remoteIp": "127.0.0.1",
+    "remoteReferrer": "",
+    "requestUuid": "Fe-tWxB8grDbVZsAAACJ",
+    "request_id": "Fe-tWxB8grDbVZsAAACJ",
+    "timestamp": 1580672602,
+    "type": "combined",
+    "url": "/213/cc2db84c-a8f6-4146-a2d9-dec62ae54564/05_99_Percent_Forgotten.mp3/"
   }
 ]


### PR DESCRIPTION
Sets up a new code path in the handler for dt-router log filter subscription records. If the incoming event record fails decompression, then assume it's a special gzipped set of records from the filter subscription. Map across the event records, decompressing and json parsing, finally flatten the resulting array.

Also, sets up impression inserts with the new columns. The dovetail router platform adds some new columns to big query impressions table: `target_path` `zone_name` `placements_key`. 