### PR TITLE
Log pingbacks

### DIFF
--- a/lib/inputs/pingbacks.js
+++ b/lib/inputs/pingbacks.js
@@ -56,6 +56,9 @@ module.exports = class Pingbacks {
   async ping(url, record, hostCounts) {
     try {
       await pingurl.ping(url, record, this._timeout, this._timeoutWait);
+      if (!url.match(/adzerk/)) {
+        logger.info('PINGED', {url});
+      }
       urlutil.count(hostCounts, url);
     } catch (err) {
       logger.warn(`PINGFAIL ${err}`, {url});

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -257,15 +257,19 @@ describe('handler', () => {
     const ping1 = nock('http://www.foo.bar').get('/ping1').reply(200);
     const ping2 = nock('http://www.foo.bar').get('/ping2').reply(404);
     const ping3 = nock('http://www.foo.bar').get('/ping3').reply(200);
-    const ping4 = nock('http://www.foo.bar').get('/ping4').reply(200);
+    const ping4 = nock('http://www.adzerk.bar').get('/ping4').reply(200);
 
     const result = await handler(event);
     expect(result).to.match(/inserted 2/i);
-    expect(infos.length).to.equal(1);
+    expect(infos.length).to.equal(3);
     expect(warns.length).to.equal(1);
     expect(errs.length).to.equal(0);
-    expect(infos[0].msg).to.match(/2 rows into www.foo.bar/);
-    expect(infos[0].meta).to.contain({dest: 'www.foo.bar', rows: 2});
+    expect(infos[0].msg).to.equal('PINGED');
+    expect(infos[0].meta).to.contain({url: 'http://www.foo.bar/ping1'});
+    expect(infos[1].msg).to.match(/1 rows into www.foo.bar/);
+    expect(infos[1].meta).to.contain({dest: 'www.foo.bar', rows: 1});
+    expect(infos[2].msg).to.match(/1 rows into www.adzerk.bar/);
+    expect(infos[2].meta).to.contain({dest: 'www.adzerk.bar', rows: 1});
     expect(warns[0]).to.match(/PINGFAIL error: http 404/i);
     expect(warns[0]).to.match(/ping2/);
 

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -54,7 +54,7 @@
         "flightId": 78,
         "isDuplicate": false,
         "cause": null,
-        "pings": ["http://www.foo.bar/ping4"]
+        "pings": ["http://www.adzerk.bar/ping4"]
       }
     ],
     "confirmed": true,


### PR DESCRIPTION
For #59.  Basically, we need to start auditing exactly which non-adzerk pingbacks we've hit.