### PR TITLE
Don't warn on missing impressions

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -13,6 +13,7 @@ exports.client = async () => {
     try {
       const RoleArn = process.env.DDB_ROLE;
       const RoleSessionName = 'analytics-ingest-lambda-dynamodb';
+      logger.info('DDB awaiting sts.assumeRole'); // TODO: temp debugging
       const data = await sts.assumeRole({RoleArn, RoleSessionName}).promise();
       const {AccessKeyId, SecretAccessKey, SessionToken} = data.Credentials;
       return new AWS.DynamoDB({region, accessKeyId: AccessKeyId, secretAccessKey: SecretAccessKey, sessionToken: SessionToken});
@@ -49,6 +50,7 @@ exports.get = async (ids, idField = 'id') => {
   const iter = new BatchGet(await exports.client(), keys);
   while (true) {
     try {
+      logger.info('DDB awaiting BatchGet.next'); // TODO: temp debugging
       const result = await iter.next();
       if (result.done === false) {
         results.push(result.value);
@@ -98,6 +100,7 @@ exports.write = async (records, idField = 'id') => {
   const iter = new BatchWrite(await exports.client(), Object.values(keys));
   while (true) {
     try {
+      logger.info('DDB awaiting BatchWrite.next'); // TODO: temp debugging
       const result = await iter.next();
       if (result.done === false) {
         numDone++;

--- a/lib/inputs/byte-downloads.js
+++ b/lib/inputs/byte-downloads.js
@@ -92,7 +92,6 @@ module.exports = class ByteDownloads {
           }],
         };
       } else {
-        logger.warn(`DDB missing segment ${record.listenerEpisode}.${record.digest}.${record.segment}`);
         return null;
       }
     }

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -199,13 +199,12 @@ describe('handler', () => {
     const result = await handler(event);
     expect(result).to.match(/inserted 4/i);
     expect(infos.length).to.equal(2);
-    expect(warns.length).to.equal(1);
+    expect(warns.length).to.equal(0);
     expect(errs.length).to.equal(0);
     expect(infos[0].msg).to.match(/inserted 3 rows into dynamodb/i);
     expect(infos[0].meta).to.contain({dest: 'dynamodb', rows: 3});
     expect(infos[1].msg).to.match(/inserted 1 rows into kinesis/i);
     expect(infos[1].meta).to.contain({dest: 'kinesis:foobar_stream', rows: 1});
-    expect(warns[0]).to.match(/missing segment listener-episode-3.the-digest.4/i);
 
     expect(dynamo.write.args[0][0].length).to.equal(3);
     expect(dynamo.write.args[0][0][0].type).to.equal('antebytes');

--- a/test/inputs-byte-downloads-test.js
+++ b/test/inputs-byte-downloads-test.js
@@ -44,14 +44,15 @@ describe('byte-downloads', () => {
   it('formats bad original records', () => {
     sinon.stub(logger, 'warn');
 
-    expect(bytes.format({type: 'bytes'}, null)).to.be.null;
+    expect(bytes.format({type: 'bytes', listenerEpisode: 'le', digest: 'd'}, null)).to.be.null;
     expect(bytes.format({type: 'segmentbytes', segment: 99}, originalRecord)).to.be.null;
     expect(bytes.format({type: 'segmentbytes', segment: null}, originalRecord)).to.be.null;
-    expect(logger.warn).to.have.callCount(3);
+    expect(logger.warn).to.have.callCount(1);
+    expect(logger.warn.args[0][0]).to.match(/DDB missing le.d/i);
 
     expect(bytes.format({type: 'bytes'}, {type: 'unknown'})).to.be.null;
-    expect(logger.warn).to.have.callCount(4);
-    expect(logger.warn.args[3][0]).to.match(/unknown ddb record type/i);
+    expect(logger.warn).to.have.callCount(2);
+    expect(logger.warn.args[1][0]).to.match(/unknown ddb record type/i);
   });
 
   it('formats record post-bytes types', () => {
@@ -226,10 +227,8 @@ describe('byte-downloads', () => {
       expect(inserts[3].impressions[0].segment).to.eql(3);
       expect(inserts[3].impressions[0].adId).to.eql(31);
 
-      expect(logger.warn).to.have.callCount(3);
+      expect(logger.warn).to.have.callCount(1);
       expect(logger.warn.args[0][0]).to.equal('DDB missing le2.does-not-exist');
-      expect(logger.warn.args[1][0]).to.equal('DDB missing segment le1.d1.0');
-      expect(logger.warn.args[2][0]).to.equal('DDB missing segment le2.d2.4');
     });
   });
 


### PR DESCRIPTION
For #61.

Thanks to PRX/dovetail-counts-lambda#26, we're now logging _all_ non-original segments that get downloaded.  Which causes this lambda to go look them up in kinesis.

However, only in Dovetail 3.0 do we log `{ impressions: [...] }` objects for non-ad segments (billboards and sonic ids).  So we're getting a ton logged warnings for Dovetail 2 downloaded sonic ids.

This PR silences that.  And adds a bit of debug logging, to try to figure out where these intermittent 30 second timeouts are happening.