### PR TITLE
Switch to async iterators

### DIFF
--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -13,7 +13,6 @@ exports.client = async () => {
     try {
       const RoleArn = process.env.DDB_ROLE;
       const RoleSessionName = 'analytics-ingest-lambda-dynamodb';
-      logger.info('DDB awaiting sts.assumeRole'); // TODO: temp debugging
       const data = await sts.assumeRole({RoleArn, RoleSessionName}).promise();
       const {AccessKeyId, SecretAccessKey, SessionToken} = data.Credentials;
       return new AWS.DynamoDB({region, accessKeyId: AccessKeyId, secretAccessKey: SecretAccessKey, sessionToken: SessionToken});
@@ -44,23 +43,16 @@ exports.get = async (ids, idField = 'id') => {
   // duplicate ids cause errors
   const uniqueIds = ids.filter((id, idx) => ids.indexOf(id) === idx);
 
-  // TODO: async iterators not supported in node 8.10
   const results = [];
   const keys = uniqueIds.map(id => [process.env.DDB_TABLE, {id: {S: id}}]);
-  const iter = new BatchGet(await exports.client(), keys);
-  while (true) {
-    try {
-      logger.info('DDB awaiting BatchGet.next'); // TODO: temp debugging
-      const result = await iter.next();
-      if (result.done === false) {
-        results.push(result.value);
-      } else {
-        break;
-      }
-    } catch (err) {
-      err.message = `DDB ${process.env.DDB_TABLE} - ${err.message}`;
-      throw err;
+  const client = await exports.client()
+  try {
+    for await (const item of new BatchGet(client, keys)) {
+      results.push(item)
     }
+  } catch (err) {
+    err.message = `DDB ${process.env.DDB_TABLE} - ${err.message}`;
+    throw err;
   }
 
   // inflate/reassemble payload, and sort by input order
@@ -95,22 +87,15 @@ exports.write = async (records, idField = 'id') => {
   const formatted = await Promise.all(records.map(r => exports.formatWrite(r, idField)));
   formatted.forEach(fmt => keys[fmt.PutRequest.Item.id.S] = [process.env.DDB_TABLE, fmt]);
 
-  // TODO: async iterators not supported in node 8.10
   let numDone = 0;
-  const iter = new BatchWrite(await exports.client(), Object.values(keys));
-  while (true) {
-    try {
-      logger.info('DDB awaiting BatchWrite.next'); // TODO: temp debugging
-      const result = await iter.next();
-      if (result.done === false) {
-        numDone++;
-      } else {
-        break;
-      }
-    } catch (err) {
-      err.message = `DDB ${process.env.DDB_TABLE} - ${err.message}`;
-      throw err;
+  const client = await exports.client();
+  try {
+    for await (const item of new BatchWrite(client, Object.values(keys))) {
+      numDone++;
     }
+  } catch (err) {
+    err.message = `DDB ${process.env.DDB_TABLE} - ${err.message}`;
+    throw err;
   }
   return numDone;
 };

--- a/lib/dynamo.js
+++ b/lib/dynamo.js
@@ -6,6 +6,7 @@ const { BatchGet, BatchWrite } = require('@aws/dynamodb-batch-iterator');
 const logger = require('./logger');
 const sts = new AWS.STS();
 const region = process.env.AWS_REGION || 'us-east-1';
+const clientOptions = {region, maxRetries: 5, httpOptions: {timeout: 1000}}
 
 // optionally load a client using a role
 exports.client = async () => {
@@ -15,13 +16,13 @@ exports.client = async () => {
       const RoleSessionName = 'analytics-ingest-lambda-dynamodb';
       const data = await sts.assumeRole({RoleArn, RoleSessionName}).promise();
       const {AccessKeyId, SecretAccessKey, SessionToken} = data.Credentials;
-      return new AWS.DynamoDB({region, accessKeyId: AccessKeyId, secretAccessKey: SecretAccessKey, sessionToken: SessionToken});
+      return new AWS.DynamoDB({...clientOptions, accessKeyId: AccessKeyId, secretAccessKey: SecretAccessKey, sessionToken: SessionToken});
     } catch (err) {
       logger.error(`STS Error [${process.env.DDB_ROLE} => ${process.env.DDB_TABLE}]: ${err}`);
-      return new AWS.DynamoDB({region});
+      return new AWS.DynamoDB(clientOptions);
     }
   } else {
-    return new AWS.DynamoDB({region});
+    return new AWS.DynamoDB(clientOptions);
   }
 };
 


### PR DESCRIPTION
- [x] Removes temporary DDB logging (it was freezing partway through the batch get items iterator)
- [x] Switch to the async iterators, now that we're on node10 (the [examples](https://www.npmjs.com/package/@aws/dynamodb-batch-iterator) are written this way).

After some debugging, I still can't figure out why the lambda was freezing partway through batchGetItems calls.  Maybe it's getting throttled by DDB read/write capacity?

So I also set a timeout of 1000ms on each individual DDB client call.  That seems pretty reasonable from my testing - anything taking longer should just get retried (they're idempotent anyways).  Also added a `maxRetries: 5` to the client.  Without that, _all_ errors including timeouts get retried with exponential backoff, putting this function way over the 60 second mark.