### PR TITLE
Retry missing ddb records

### DIFF
--- a/env-example
+++ b/env-example
@@ -9,6 +9,7 @@ DDB_TABLE=
 DDB_ROLE=
 DDB_TTL=
 KINESIS_STREAM=
+KINESIS_RETRY_STREAM=
 # pingbacks mode
 PINGBACKS=
 # redis mode

--- a/lib/inputs/byte-downloads.js
+++ b/lib/inputs/byte-downloads.js
@@ -44,9 +44,11 @@ module.exports = class ByteDownloads {
             formatted.push(format);
           }
         } else if (this.shouldRetry(rec)) {
-          retries.push(this.formatRetry(rec));
+          const retry = this.formatRetry(rec);
+          logger.warn(`DDB retrying ${key}`, {ddb: 'retrying', count: rec.retryCount});
+          retries.push(retry);
         } else {
-          logger.warn(`DDB missing ${key}`);
+          logger.warn(`DDB missing ${key}`, {ddb: 'missing'});
         }
       });
 

--- a/lib/inputs/byte-downloads.js
+++ b/lib/inputs/byte-downloads.js
@@ -4,6 +4,9 @@ const dynamo = require('../dynamo');
 const kinesis = require('../kinesis');
 const logger = require('../logger');
 
+const MAX_RETRIES = 20;
+const MAX_RETRY_MS = 300 * 1000;
+
 /**
  * Pull records out of DynamoDB when their bytes are downloaded from the CDN
  */
@@ -30,20 +33,39 @@ module.exports = class ByteDownloads {
       const originals = await this.lookup();
 
       // format using the original ddb record
-      const formatted = this._records.map(r => {
-        return this.format(r, originals[`${r.listenerEpisode}.${r.digest}`]);
+      const formatted = [];
+      const retries = [];
+      this._records.forEach(rec => {
+        const key = `${rec.listenerEpisode}.${rec.digest}`
+        const orig = originals[key];
+        if (orig) {
+          const format = this.format(rec, orig);
+          if (format) {
+            formatted.push(format);
+          }
+        } else if (this.shouldRetry(rec)) {
+          retries.push(this.formatRetry(rec));
+        } else {
+          logger.warn(`DDB missing ${key}`);
+        }
       });
-      const filtered = formatted.filter(r => r);
 
       // throw back onto kinesis
-      const count = await kinesis.put(filtered);
-      return [{count, dest: `kinesis:${kinesis.stream()}`}];
+      const result = [];
+      if (formatted.length) {
+        const count = await kinesis.put(formatted);
+        result.push({count, dest: `kinesis:${kinesis.stream()}`});
+      }
+      if (retries.length) {
+        const count = await kinesis.putRetry(retries);
+        result.push({count, dest: `kinesis:${kinesis.retryStream()}`});
+      }
+      return result;
     }
   }
 
   format(record, original) {
     if (!original) {
-      logger.warn(`DDB missing ${record.listenerEpisode}.${record.digest}`);
       return null;
     }
     if (!(original.type === 'antebytes' || original.type === 'antebytespreview')) {
@@ -54,7 +76,7 @@ module.exports = class ByteDownloads {
     // set record type so DovetailDownloads/Impressions will pick it up
     const postBytes = {
       type: original.type.replace('ante', 'post'),
-      timestamp: record.timestamp || new Date().getTime(),
+      timestamp: record.timestamp || Date.now(),
       listenerEpisode: record.listenerEpisode,
       listenerId: original.listenerId,
       requestUuid: original.requestUuid,
@@ -94,6 +116,31 @@ module.exports = class ByteDownloads {
       } else {
         return null;
       }
+    }
+  }
+
+  // mark when/how-many-times we're retrying
+  formatRetry(record) {
+    if (record.retryCount) {
+      record.retryCount++;
+    } else {
+      record.retryCount = 1;
+    }
+    if (!record.retryAt) {
+      record.retryAt = Date.now();
+    }
+    return record;
+  }
+
+  // handle race condition, where dovetail-counts-lambda has us trying to read
+  // from DDB before dovetail.prx.org has gotten the record written.
+  shouldRetry(record) {
+    if (record.retryCount && record.retryCount >= MAX_RETRIES) {
+      return false;
+    } else if (record.retryAt && (Date.now() - record.retryAt) > MAX_RETRY_MS) {
+      return false;
+    } else {
+      return true;
     }
   }
 

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -12,30 +12,49 @@ exports.stream = () => {
     return null;
   }
 };
+exports.retryStream = () => {
+  if (process.env.KINESIS_RETRY_STREAM) {
+    return process.env.KINESIS_RETRY_STREAM.replace(/^.+stream\//, '');
+  } else {
+    return null;
+  }
+};
 
 /**
  * Batch put records to kinesis
  */
-exports.put = async (datas, maxChunk = 200) => {
-  if (!datas || datas.length === 0) {
-    return 0;
-  }
+exports.put = (datas, maxChunk = 200) => {
   if (!exports.stream()) {
     throw new Error('You must set a KINESIS_STREAM');
   }
+  return putInChunks(exports.stream(), datas, maxChunk);
+};
+exports.putRetry = (datas, maxChunk = 200) => {
+  if (!exports.retryStream()) {
+    throw new Error('You must set a KINESIS_RETRY_STREAM');
+  }
+  return putInChunks(exports.retryStream(), datas, maxChunk);
+};
+
+/**
+ * Chunk input and call kinesis.putRecords
+ */
+async function putInChunks(streamName, datas, maxChunk) {
+  if (!datas || datas.length === 0) {
+    return 0;
+  }
   if (!Array.isArray(datas)) {
-    return await exports.put([datas]);
+    return await putInChunks(streamName, [datas], maxChunk);
   }
   if (datas.length > maxChunk) {
     const chunks = chunkArray(datas, maxChunk);
-    const nums = await Promise.all(chunks.map(c => exports.put(c, maxChunk)));
+    const nums = await Promise.all(chunks.map(c => putInChunks(streamName, c, maxChunk)));
     return nums.reduce((a, b) => a + b, 0);
   }
 
   // format records and insert
-  const StreamName = exports.stream();
   const Records = datas.map(r => dataToRecord(r));
-  await exports.client.putRecords({StreamName, Records}).promise();
+  await exports.client.putRecords({StreamName: streamName, Records}).promise();
   return datas.length;
 };
 

--- a/test/inputs-byte-downloads-test.js
+++ b/test/inputs-byte-downloads-test.js
@@ -267,9 +267,15 @@ describe('byte-downloads', () => {
       expect(retries[1].retryCount).to.equal(3);
       expect(retries[1].retryAt).to.equal(9999999999999);
 
-      expect(logger.warn).to.have.callCount(2);
-      expect(logger.warn.args[0][0]).to.equal('DDB missing le3.out-of-retries');
-      expect(logger.warn.args[1][0]).to.equal('DDB missing le3.out-of-time');
+      expect(logger.warn).to.have.callCount(4);
+      expect(logger.warn.args[0][0]).to.equal('DDB retrying le3.brand-new');
+      expect(logger.warn.args[0][1]).to.eql({ddb: 'retrying', count: 1});
+      expect(logger.warn.args[1][0]).to.equal('DDB retrying le3.still-retryable');
+      expect(logger.warn.args[1][1]).to.eql({ddb: 'retrying', count: 3});
+      expect(logger.warn.args[2][0]).to.equal('DDB missing le3.out-of-retries');
+      expect(logger.warn.args[2][1]).to.eql({ddb: 'missing'});
+      expect(logger.warn.args[3][0]).to.equal('DDB missing le3.out-of-time');
+      expect(logger.warn.args[3][1]).to.eql({ddb: 'missing'});
     });
   });
 

--- a/test/inputs-byte-downloads-test.js
+++ b/test/inputs-byte-downloads-test.js
@@ -47,12 +47,10 @@ describe('byte-downloads', () => {
     expect(bytes.format({type: 'bytes', listenerEpisode: 'le', digest: 'd'}, null)).to.be.null;
     expect(bytes.format({type: 'segmentbytes', segment: 99}, originalRecord)).to.be.null;
     expect(bytes.format({type: 'segmentbytes', segment: null}, originalRecord)).to.be.null;
-    expect(logger.warn).to.have.callCount(1);
-    expect(logger.warn.args[0][0]).to.match(/DDB missing le.d/i);
 
     expect(bytes.format({type: 'bytes'}, {type: 'unknown'})).to.be.null;
-    expect(logger.warn).to.have.callCount(2);
-    expect(logger.warn.args[1][0]).to.match(/unknown ddb record type/i);
+    expect(logger.warn).to.have.callCount(1);
+    expect(logger.warn.args[0][0]).to.match(/unknown ddb record type/i);
   });
 
   it('formats record post-bytes types', () => {
@@ -140,6 +138,23 @@ describe('byte-downloads', () => {
     });
   });
 
+  it('formats retry records', () => {
+    sinon.stub(Date, 'now').returns(9999);
+    expect(bytes.formatRetry({})).to.eql({retryCount: 1, retryAt: 9999});
+    expect(bytes.formatRetry({retryCount: 2})).to.eql({retryCount: 3, retryAt: 9999});
+    expect(bytes.formatRetry({retryAt: 8888})).to.eql({retryCount: 1, retryAt: 8888});
+    expect(bytes.formatRetry({retryCount: 2, retryAt: 8888})).to.eql({retryCount: 3, retryAt: 8888});
+  });
+
+  it('checks if records are retryable', () => {
+    sinon.stub(Date, 'now').returns(400000);
+    expect(bytes.shouldRetry({})).to.equal(true);
+    expect(bytes.shouldRetry({retryCount: 19})).to.equal(true);
+    expect(bytes.shouldRetry({retryCount: 20})).to.equal(false);
+    expect(bytes.shouldRetry({retryAt: 100000})).to.equal(true);
+    expect(bytes.shouldRetry({retryAt: 99999})).to.equal(false);
+  });
+
   it('looks up dynamodb records', async () => {
     const bytes = new ByteDownloads([
       {listenerEpisode: 'le1', digest: 'd1', type: 'bytes'},
@@ -167,9 +182,13 @@ describe('byte-downloads', () => {
   });
 
   it('inserts kinesis records', () => {
-    let inserts = [];
+    let inserts = [], retries = [];
     sinon.stub(kinesis, 'put').callsFake((recs) => {
       inserts = inserts.concat(recs);
+      return Promise.resolve(recs.length);
+    });
+    sinon.stub(kinesis, 'putRetry').callsFake((recs) => {
+      retries = retries.concat(recs);
       return Promise.resolve(recs.length);
     });
 
@@ -183,17 +202,25 @@ describe('byte-downloads', () => {
     const bytes = new ByteDownloads([
       {listenerEpisode: 'le1', digest: 'd1', type: 'bytes', timestamp: 1234},
       {listenerEpisode: 'le1', digest: 'd1', type: 'bytes', timestamp: 5678, isDuplicate: true},
-      {listenerEpisode: 'le2', digest: 'does-not-exist', type: 'bytes'},
       {listenerEpisode: 'le1', digest: 'd1', segment: 2, type: 'segmentbytes'},
       {listenerEpisode: 'le1', digest: 'd1', segment: 0, type: 'segmentbytes'},
       {listenerEpisode: 'le2', digest: 'd2', segment: 3, type: 'segmentbytes'},
       {listenerEpisode: 'le2', digest: 'd2', segment: 4, type: 'segmentbytes'},
+      // ignored segment not in the DDB record
+      {listenerEpisode: 'le2', digest: 'd2', segment: 999, type: 'segmentbytes'},
+      // le.digests not found in DDB (retry candidates)
+      {type: 'bytes', listenerEpisode: 'le3', digest: 'brand-new'},
+      {type: 'bytes', listenerEpisode: 'le3', digest: 'still-retryable', retryCount: 2, retryAt: 9999999999999},
+      {type: 'bytes', listenerEpisode: 'le3', digest: 'out-of-retries', retryCount: 999},
+      {type: 'bytes', listenerEpisode: 'le3', digest: 'out-of-time', retryAt: 1000},
     ]);
 
     return bytes.insert().then(result => {
-      expect(result.length).to.equal(1);
+      expect(result.length).to.equal(2);
       expect(result[0].dest).to.equal('kinesis:foobar_stream');
       expect(result[0].count).to.equal(4);
+      expect(result[1].dest).to.equal('kinesis:foobar_retry_stream');
+      expect(result[1].count).to.equal(2);
 
       expect(inserts.length).to.equal(4);
 
@@ -227,8 +254,22 @@ describe('byte-downloads', () => {
       expect(inserts[3].impressions[0].segment).to.eql(3);
       expect(inserts[3].impressions[0].adId).to.eql(31);
 
-      expect(logger.warn).to.have.callCount(1);
-      expect(logger.warn.args[0][0]).to.equal('DDB missing le2.does-not-exist');
+      expect(retries.length).to.equal(2);
+
+      expect(retries[0].type).to.equal('bytes');
+      expect(retries[0].digest).to.equal('brand-new');
+      expect(retries[0].retryCount).to.equal(1);
+      expect(retries[0].retryAt).to.be.at.most(new Date().getTime());
+      expect(retries[0].retryAt).to.be.at.least(new Date().getTime() - 10);
+
+      expect(retries[1].type).to.equal('bytes');
+      expect(retries[1].digest).to.equal('still-retryable');
+      expect(retries[1].retryCount).to.equal(3);
+      expect(retries[1].retryAt).to.equal(9999999999999);
+
+      expect(logger.warn).to.have.callCount(2);
+      expect(logger.warn.args[0][0]).to.equal('DDB missing le3.out-of-retries');
+      expect(logger.warn.args[1][0]).to.equal('DDB missing le3.out-of-time');
     });
   });
 

--- a/test/kinesis-test.js
+++ b/test/kinesis-test.js
@@ -29,6 +29,21 @@ describe('kinesis', () => {
     }
   });
 
+  it('requires a KINESIS_RETRY_STREAM env', async () => {
+    let err = null;
+    try {
+      delete process.env.KINESIS_RETRY_STREAM;
+      await kinesis.putRetry('anything');
+    } catch (e) {
+      err = e;
+    }
+    if (err) {
+      expect(err.message).to.match(/must set a KINESIS_RETRY_STREAM/);
+    } else {
+      expect.fail('should have thrown an error');
+    }
+  });
+
   it('changes kinesis arns into stream names', () => {
     process.env.KINESIS_STREAM = 'table_name';
     expect(kinesis.stream()).to.equal('table_name');
@@ -40,6 +55,7 @@ describe('kinesis', () => {
 
   it('puts nothing', async () => {
     expect(await kinesis.put([])).to.equal(0);
+    expect(await kinesis.putRetry([])).to.equal(0);
     expect(puts.length).to.equal(0);
   });
 

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -11,6 +11,7 @@ beforeEach(() => {
   process.env.DDB_TTL = '';
   process.env.DYNAMODB = '';
   process.env.KINESIS_STREAM = 'foobar_stream';
+  process.env.KINESIS_RETRY_STREAM = 'foobar_retry_stream';
   process.env.PINGBACKS = '';
   process.env.REDIS_HOST = '';
   process.env.REDIS_TTL = '7200';


### PR DESCRIPTION
I've been seeing more `DDB missing <key>` warnings in the prod DDB lambda than I'd like.  Involves these 2 flows from our dovetail [IAB 2 flow](https://github.com/PRX/internal/blob/master/devops/dovetail.md#iab2-overview).

1. Dovetail ECS redirect data -> kinesis -> analytics-ddb-lambda
2. Dovetail counts lambda -> kinesis -> analytics-ddb-lambda

It seems (2) beats (1) in these small % of cases, so it tries to read the redirect data before it exists.

When that occurs, this PR will have (2) recycle the redirect data onto the same input kinesis stream.  But adding the keys `{ retryCount: 1, retryAt: <ms_epoch> }`.  And those records will get retried until they hit 20 retries, or 5-minutes since the first retry.

I have no idea if that's the right retry logic, but from what I've seen (2) only beats (1) by < one second.  So unless things are going real fast, 1 retry may do it.