### PR TITLE
Unique string set keys

### DIFF
--- a/lib/inputs/dynamodb-data.js
+++ b/lib/inputs/dynamodb-data.js
@@ -24,10 +24,13 @@ module.exports = class DynamodbData {
       const [key, rec] = this.encodeKey(raw);
       if (rec.type === 'antebytes' || rec.type === 'antebytespreview') {
         this.payloads[key] = rec;
-      } else if (this.segments[key]) {
-        this.segments[key].push(this.encodeSegment(rec));
       } else {
-        this.segments[key] = [this.encodeSegment(rec)];
+        const segment = this.encodeSegment(rec);
+        if (this.segments[key] && !this.segments[key].includes(segment)) {
+          this.segments[key].push(segment);
+        } else if (!this.segments[key]) {
+          this.segments[key] = [segment];
+        }
       }
     });
   }

--- a/test/inputs-dynamodb-data-test.js
+++ b/test/inputs-dynamodb-data-test.js
@@ -24,6 +24,20 @@ describe('dynamodb-data', () => {
     });
   });
 
+  it('dedups segments', () => {
+    const recs = [
+      { listenerEpisode: 'le1', digest: 'd1', timestamp: 2000, type: 'bytes' },
+      { listenerEpisode: 'le1', digest: 'd1', timestamp: 2000, type: 'bytes' },
+      { listenerEpisode: 'le1', digest: 'd1', timestamp: 4000, type: 'segmentbytes', segment: 2 },
+      { listenerEpisode: 'le1', digest: 'd1', timestamp: 4000, type: 'segmentbytes', segment: 2 },
+    ];
+    const ddb = new DynamodbData(recs);
+
+    expect(ddb.segments).to.eql({
+      'le1.d1': ['2000', '4000.2'],
+    });
+  });
+
   it('recognizes antebytes and bytes records', () => {
     const ddb = new DynamodbData();
 


### PR DESCRIPTION
Patched in prod already, but this is the code I changed.

I guess when setting DynamoDB String Sets, the input keys must be unique.  So this checks for that as the kinesis input records come in.