### PR TITLE
Ignore digestCache records

### DIFF
--- a/lib/inputs/dynamodb-data.js
+++ b/lib/inputs/dynamodb-data.js
@@ -35,7 +35,13 @@ module.exports = class DynamodbData {
   }
 
   check(record) {
-    return ['antebytes', 'antebytespreview', 'bytes', 'segmentbytes'].includes(record.type);
+    if (record.type === 'antebytes' || record.type === 'antebytespreview') {
+      return true;
+    } else if (record.type === 'bytes' || record.type === 'segmentbytes') {
+      return !record.isDuplicate;
+    } else {
+      return false;
+    }
   }
 
   encodeKey({ listenerEpisode, digest, ...record }) {

--- a/lib/inputs/dynamodb-data.js
+++ b/lib/inputs/dynamodb-data.js
@@ -104,7 +104,6 @@ module.exports = class DynamodbData {
 
   // spin up N workers, and process the queue of updates
   async updateAll(updates, concurrency = 25) {
-    console.log(`updateAll[START] - ${updates.length}`);
     let successCount = 0;
     let failureCount = 0;
     let loggedCount = 0;
@@ -113,7 +112,6 @@ module.exports = class DynamodbData {
     const worker = async () => {
       let args;
       while ((args = updates.shift())) {
-        console.log(`updateAll[UPDATE] - ${args[0]}`);
         try {
           const result = await dynamo.update.apply(this, args.concat([client]));
           successCount++;
@@ -121,22 +119,15 @@ module.exports = class DynamodbData {
             logger.info('impression', formatted);
             loggedCount++;
           });
-          console.log(
-            `updateAll[SUCCESS] - ${args[0]} - ${successCount} success, ${failureCount} failed, ${loggedCount} logged, ${updates.length} remain`,
-          );
         } catch (err) {
           logger.error(`DDB Error [${process.env.DDB_TABLE}]: ${err}`, { args });
           failureCount++;
-          console.log(
-            `updateAll[FAILURE] - ${args[0]} - ${successCount} success, ${failureCount} failed, ${loggedCount} logged, ${updates.length} remain`,
-          );
         }
       }
     };
 
     const threads = Array(concurrency).fill(true);
     await Promise.all(threads.map(() => worker()));
-    console.log(`END updateAll`);
     return [successCount, failureCount, loggedCount];
   }
 

--- a/test/inputs-dynamodb-data-test.js
+++ b/test/inputs-dynamodb-data-test.js
@@ -50,6 +50,17 @@ describe('dynamodb-data', () => {
     expect(ddb.check({ type: 'segmentbytes' })).to.be.true;
   });
 
+  it('ignores duplicate bytes and segmentbytes records', () => {
+    const ddb = new DynamodbData();
+    const isDuplicate = true;
+    const cause = 'digestCache';
+
+    expect(ddb.check({ type: 'antebytes', isDuplicate, cause })).to.be.true;
+    expect(ddb.check({ type: 'antebytespreview', isDuplicate, cause })).to.be.true;
+    expect(ddb.check({ type: 'bytes', isDuplicate, cause })).to.be.false;
+    expect(ddb.check({ type: 'segmentbytes', isDuplicate, cause })).to.be.false;
+  });
+
   it('encodes payload keys', () => {
     const ddb = new DynamodbData();
     const data = { listenerEpisode: 'a', digest: 'b' };


### PR DESCRIPTION
Fixes #84.

We used to insert these into BigQuery, with the usual `is_duplicate = true` and `cause = "digestCache"`.  Since the refactor in #75 to solve a race condition, it's a bit difficult to do that.  So instead - just don't insert them at all!  They never had a ton of value - the `is_duplicate = true` records in BigQuery are basically a debugging feature.  And not useful day-to-day.