### PR TITLE
Deprecate columns

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,22 +1,22 @@
 version: 0.2
 env:
   variables:
-    PRX_LAMBDA_CODE_CONFIG_PARAMETERS: "AnalyticsIngestLambdaCodeS3ObjectKey"
-    PRX_LAMBDA_ARCHIVE_BUILD_PATH: "/app/build.zip"
+    PRX_LAMBDA_CODE_CONFIG_PARAMETERS: 'AnalyticsIngestLambdaCodeS3ObjectKey'
+    PRX_LAMBDA_ARCHIVE_BUILD_PATH: '/app/build.zip'
   parameter-store:
-    MAXMIND_LICENSE_KEY: "/prx/test/analytics-ingest-lambda/MAXMIND_LICENSE_KEY"
-    S3_ACCESS_KEY_ID: "/prx/test/analytics-ingest-lambda/AWS_ACCESS_KEY_ID"
-    S3_SECRET_ACCESS_KEY: "/prx/test/analytics-ingest-lambda/AWS_SECRET_ACCESS_KEY"
-    CODECOV_TOKEN: "/prx/test/dovetail.prx.org/CODECOV_TOKEN"
+    MAXMIND_LICENSE_KEY: '/prx/test/analytics-ingest-lambda/MAXMIND_LICENSE_KEY'
+    S3_ACCESS_KEY_ID: '/prx/test/analytics-ingest-lambda/AWS_ACCESS_KEY_ID'
+    S3_SECRET_ACCESS_KEY: '/prx/test/analytics-ingest-lambda/AWS_SECRET_ACCESS_KEY'
+    CODECOV_TOKEN: '/prx/test/analytics-ingest-lambda/CODECOV_TOKEN'
   exported-variables:
     - PRX_LAMBDA_CODE_CONFIG_PARAMETERS
     - PRX_LAMBDA_CODE_CONFIG_VALUE
 phases:
   build:
     commands:
-      - "cp env-example .env"
-      - "docker-compose build"
-      - "docker-compose run test"
+      - 'cp env-example .env'
+      - 'docker-compose build'
+      - 'docker-compose run test'
   post_build:
     commands:
       - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && . ./post_build.sh'

--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -65,11 +65,10 @@ module.exports = class DovetailDownloads {
 
   async format(record) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
-    const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
     const info = await assayer.test(record, true);
 
     return {
-      insertId: `${listenerSession}/${epoch}`,
+      insertId: `${record.listenerEpisode}/${epoch}`,
       json: {
         timestamp: epoch,
         request_uuid: record.requestUuid || uuid.v4(),
@@ -81,12 +80,10 @@ module.exports = class DovetailDownloads {
         is_duplicate: info.isDuplicate,
         cause: info.cause,
         is_confirmed: !!record.confirmed,
-        is_bytes: this.isBytes(record),
         url: record.url,
         // listener data
         listener_id: record.listenerId,
         listener_episode: record.listenerEpisode,
-        listener_session: listenerSession,
         // request data
         remote_referrer: record.remoteReferrer,
         remote_agent: record.remoteAgent,
@@ -97,14 +94,7 @@ module.exports = class DovetailDownloads {
         agent_os_id: info.agent.os,
         city_geoname_id: info.geo.city,
         country_geoname_id: info.geo.country,
-        postal_code: info.geo.postal,
-        latitude: info.geo.latitude,
-        longitude: info.geo.longitude,
       },
     };
-  }
-
-  isBytes(record) {
-    return record.type === 'postbytes' || record.type === 'postbytespreview';
   }
 };

--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -9,13 +9,16 @@ const bigquery = require('../bigquery');
  * Send dovetail downloads to bigquery
  */
 module.exports = class DovetailDownloads {
-
   constructor(records) {
     this._records = (records || []).filter(r => this.check(r));
   }
 
   check(record) {
-    if (record.type === 'combined' || record.type === 'postbytes' || record.type === 'postbytespreview') {
+    if (
+      record.type === 'combined' ||
+      record.type === 'postbytes' ||
+      record.type === 'postbytespreview'
+    ) {
       return !!record.download;
     } else {
       return false;
@@ -37,23 +40,27 @@ module.exports = class DovetailDownloads {
 
     // format records and organize by table name
     const formatted = {};
-    await Promise.all(this._records.map(async (rec) => {
-      const name = this.tableName(rec);
-      const formattedRec = await this.format(rec);
-      if (formatted[name]) {
-        formatted[name].push(formattedRec);
-      } else {
-        formatted[name] = [formattedRec];
-      }
-    }));
+    await Promise.all(
+      this._records.map(async rec => {
+        const name = this.tableName(rec);
+        const formattedRec = await this.format(rec);
+        if (formatted[name]) {
+          formatted[name].push(formattedRec);
+        } else {
+          formatted[name] = [formattedRec];
+        }
+      }),
+    );
     const tableNames = Object.keys(formatted);
 
     // insert in parallel
     const ds = process.env.BQ_DATASET || '';
-    return await Promise.all(tableNames.map(async (tbl) => {
-      const num = await bigquery.insert(ds, tbl, formatted[tbl]);
-      return {count: num, dest: tbl};
-    }));
+    return await Promise.all(
+      tableNames.map(async tbl => {
+        const num = await bigquery.insert(ds, tbl, formatted[tbl]);
+        return { count: num, dest: tbl };
+      }),
+    );
   }
 
   async format(record) {
@@ -64,41 +71,40 @@ module.exports = class DovetailDownloads {
     return {
       insertId: `${listenerSession}/${epoch}`,
       json: {
-        timestamp:          epoch,
-        request_uuid:       record.requestUuid || uuid.v4(),
+        timestamp: epoch,
+        request_uuid: record.requestUuid || uuid.v4(),
         // redirect data
-        feeder_podcast:     record.feederPodcast,
-        feeder_episode:     record.feederEpisode,
-        digest:             record.digest,
-        ad_count:           record.download.adCount,
-        is_duplicate:       info.isDuplicate,
-        cause:              info.cause,
-        is_confirmed:       !!record.confirmed,
-        is_bytes:           this.isBytes(record),
-        url:                record.url,
+        feeder_podcast: record.feederPodcast,
+        feeder_episode: record.feederEpisode,
+        digest: record.digest,
+        ad_count: record.download.adCount,
+        is_duplicate: info.isDuplicate,
+        cause: info.cause,
+        is_confirmed: !!record.confirmed,
+        is_bytes: this.isBytes(record),
+        url: record.url,
         // listener data
-        listener_id:        record.listenerId,
-        listener_episode:   record.listenerEpisode,
-        listener_session:   listenerSession,
+        listener_id: record.listenerId,
+        listener_episode: record.listenerEpisode,
+        listener_session: listenerSession,
         // request data
-        remote_referrer:    record.remoteReferrer,
-        remote_agent:       record.remoteAgent,
-        remote_ip:          info.geo.masked,
+        remote_referrer: record.remoteReferrer,
+        remote_agent: record.remoteAgent,
+        remote_ip: info.geo.masked,
         // derived data
-        agent_name_id:      info.agent.name,
-        agent_type_id:      info.agent.type,
-        agent_os_id:        info.agent.os,
-        city_geoname_id:    info.geo.city,
+        agent_name_id: info.agent.name,
+        agent_type_id: info.agent.type,
+        agent_os_id: info.agent.os,
+        city_geoname_id: info.geo.city,
         country_geoname_id: info.geo.country,
-        postal_code:        info.geo.postal,
-        latitude:           info.geo.latitude,
-        longitude:          info.geo.longitude
-      }
+        postal_code: info.geo.postal,
+        latitude: info.geo.latitude,
+        longitude: info.geo.longitude,
+      },
     };
   }
 
   isBytes(record) {
     return record.type === 'postbytes' || record.type === 'postbytespreview';
   }
-
 };

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -64,19 +64,16 @@ module.exports = class DovetailImpressions {
 
   async format(record, imp) {
     const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
-    const listenerSession = timestamp.toDigest(record.listenerEpisode, epoch);
     const info = await assayer.testImpression(record, imp);
     let out = {
-      insertId: this.md5InsertId(`${listenerSession}/${epoch}`, imp),
+      insertId: this.md5InsertId(`${record.listenerEpisode}/${epoch}`, imp),
       json: {
         timestamp: epoch,
         request_uuid: record.requestUuid || uuid.v4(),
         feeder_podcast: record.feederPodcast,
         feeder_episode: record.feederEpisode,
         digest: record.digest,
-        listener_session: listenerSession,
         is_confirmed: !!record.confirmed,
-        is_bytes: this.isBytes(record),
         segment: imp.segment,
         ad_id: imp.adId,
         campaign_id: imp.campaignId,
@@ -119,10 +116,6 @@ module.exports = class DovetailImpressions {
       impression.flightId,
     ].join('-');
     return crypto.createHash('md5').update(parts).digest('hex');
-  }
-
-  isBytes(record) {
-    return record.type === 'postbytes' || record.type === 'postbytespreview';
   }
 
   async eachImpression(handler) {

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -10,13 +10,16 @@ const bigquery = require('../bigquery');
  * Send dovetail impressions to bigquery
  */
 module.exports = class DovetailImpressions {
-
   constructor(records) {
     this._records = (records || []).filter(r => this.check(r));
   }
 
   check(record) {
-    if (record.type === 'combined' || record.type === 'postbytes' || record.type === 'postbytespreview') {
+    if (
+      record.type === 'combined' ||
+      record.type === 'postbytes' ||
+      record.type === 'postbytespreview'
+    ) {
       return (record.impressions || []).length > 0;
     } else {
       return false;
@@ -51,10 +54,12 @@ module.exports = class DovetailImpressions {
 
     // insert in parallel
     const ds = process.env.BQ_DATASET || '';
-    return await Promise.all(tableNames.map(async (tbl) => {
-      const num = await bigquery.insert(ds, tbl, formatted[tbl]);
-      return {count: num, dest: tbl};
-    }));
+    return await Promise.all(
+      tableNames.map(async tbl => {
+        const num = await bigquery.insert(ds, tbl, formatted[tbl]);
+        return { count: num, dest: tbl };
+      }),
+    );
   }
 
   async format(record, imp) {
@@ -64,25 +69,25 @@ module.exports = class DovetailImpressions {
     let out = {
       insertId: this.md5InsertId(`${listenerSession}/${epoch}`, imp),
       json: {
-        timestamp:        epoch,
-        request_uuid:     record.requestUuid || uuid.v4(),
-        feeder_podcast:   record.feederPodcast,
-        feeder_episode:   record.feederEpisode,
-        digest:           record.digest,
+        timestamp: epoch,
+        request_uuid: record.requestUuid || uuid.v4(),
+        feeder_podcast: record.feederPodcast,
+        feeder_episode: record.feederEpisode,
+        digest: record.digest,
         listener_session: listenerSession,
-        is_confirmed:     !!record.confirmed,
-        is_bytes:         this.isBytes(record),
-        segment:          imp.segment,
-        ad_id:            imp.adId,
-        campaign_id:      imp.campaignId,
-        creative_id:      imp.creativeId,
-        flight_id:        imp.flightId,
-        target_path:      imp.targetPath || null,
-        zone_name:        imp.zoneName || null,
-        placements_key:   imp.placementsKey || null,
-        is_duplicate:     info.isDuplicate,
-        cause:            info.cause
-      }
+        is_confirmed: !!record.confirmed,
+        is_bytes: this.isBytes(record),
+        segment: imp.segment,
+        ad_id: imp.adId,
+        campaign_id: imp.campaignId,
+        creative_id: imp.creativeId,
+        flight_id: imp.flightId,
+        target_path: imp.targetPath || null,
+        zone_name: imp.zoneName || null,
+        placements_key: imp.placementsKey || null,
+        is_duplicate: info.isDuplicate,
+        cause: info.cause,
+      },
     };
 
     if (imp.vast) {
@@ -111,7 +116,7 @@ module.exports = class DovetailImpressions {
       impression.adId,
       impression.campaignId,
       impression.creativeId,
-      impression.flightId
+      impression.flightId,
     ].join('-');
     return crypto.createHash('md5').update(parts).digest('hex');
   }
@@ -121,11 +126,14 @@ module.exports = class DovetailImpressions {
   }
 
   async eachImpression(handler) {
-    await Promise.all(this._records.map(async (rec) => {
-      await Promise.all(rec.impressions.map(async (imp) => {
-        await handler(rec, imp);
-      }));
-    }));
+    await Promise.all(
+      this._records.map(async rec => {
+        await Promise.all(
+          rec.impressions.map(async imp => {
+            await handler(rec, imp);
+          }),
+        );
+      }),
+    );
   }
-
 };

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -74,9 +74,6 @@ module.exports = class PixelTrackers {
         remote_ip: info.geo.masked,
         city_geoname_id: info.geo.city,
         country_geoname_id: info.geo.country,
-        postal_code: info.geo.postal,
-        latitude: info.geo.latitude,
-        longitude: info.geo.longitude,
       },
     };
   }

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -1,109 +1,109 @@
-const crypto = require('crypto')
-const logger = require('../logger')
-const timestamp = require('../timestamp')
-const assayer = require('../assayer')
-const bigquery = require('../bigquery')
+const crypto = require('crypto');
+const logger = require('../logger');
+const timestamp = require('../timestamp');
+const assayer = require('../assayer');
+const bigquery = require('../bigquery');
 
 /**
  * Pixel.prx.org trackers
  */
 module.exports = class PixelTrackers {
-
   constructor(records) {
-    this._records = (records || []).filter(r => this.check(r))
+    this._records = (records || []).filter(r => this.check(r));
   }
 
   check(record) {
-    return record.type === 'pixel'
+    return record.type === 'pixel';
   }
 
   async insert() {
     if (this._records.length === 0) {
-      return []
+      return [];
     }
 
     // format records and organize by dataset + table
-    const formatted = await Promise.all(this._records.map(r => this.format(r)))
+    const formatted = await Promise.all(this._records.map(r => this.format(r)));
     const grouped = this._records.reduce((acc, rec, idx) => {
-      const dest = this.destination(rec)
+      const dest = this.destination(rec);
       if (dest) {
-        (acc[dest] = acc[dest] || []).push(formatted[idx])
+        (acc[dest] = acc[dest] || []).push(formatted[idx]);
       }
-      return acc
-    }, {})
+      return acc;
+    }, {});
 
     // insert in parallel
-    return await Promise.all(Object.keys(grouped).map(async (datasetTable) => {
-      try {
-        const [ds, tbl] = datasetTable.split('.')
-        const num = await bigquery.insert(ds, tbl, grouped[datasetTable])
-        return {count: num, dest: datasetTable}
-      } catch (err) {
-        if (err.code === 404) {
-          logger.error(`Table not found: ${datasetTable}`)
-          return {count: 0, dest: datasetTable}
-        } else {
-          const insertErrors = logger.combineErrors(err)
-          if (insertErrors) {
-            logger.error(`Insert errors on ${datasetTable}: ${insertErrors}`)
-            return {count: 0, dest: datasetTable}
+    return await Promise.all(
+      Object.keys(grouped).map(async datasetTable => {
+        try {
+          const [ds, tbl] = datasetTable.split('.');
+          const num = await bigquery.insert(ds, tbl, grouped[datasetTable]);
+          return { count: num, dest: datasetTable };
+        } catch (err) {
+          if (err.code === 404) {
+            logger.error(`Table not found: ${datasetTable}`);
+            return { count: 0, dest: datasetTable };
           } else {
-            throw err
+            const insertErrors = logger.combineErrors(err);
+            if (insertErrors) {
+              logger.error(`Insert errors on ${datasetTable}: ${insertErrors}`);
+              return { count: 0, dest: datasetTable };
+            } else {
+              throw err;
+            }
           }
         }
-      }
-    }))
+      }),
+    );
   }
 
   async format(record) {
-    const epoch = timestamp.toEpochSeconds(record.timestamp || 0)
-    const userId = this.userId(record)
-    const info = await assayer.test(record, true)
+    const epoch = timestamp.toEpochSeconds(record.timestamp || 0);
+    const userId = this.userId(record);
+    const info = await assayer.test(record, true);
 
     // TODO: info.isDuplicates?
     return {
       insertId: this.insertId(epoch, userId, record.key, record.canonical),
       json: {
-        timestamp:          epoch,
-        user_id:            userId,
-        key:                record.key,
-        canonical:          record.canonical,
-        remote_agent:       record.remoteAgent,
-        remote_referrer:    record.remoteReferrer,
-        remote_ip:          info.geo.masked,
-        city_geoname_id:    info.geo.city,
+        timestamp: epoch,
+        user_id: userId,
+        key: record.key,
+        canonical: record.canonical,
+        remote_agent: record.remoteAgent,
+        remote_referrer: record.remoteReferrer,
+        remote_ip: info.geo.masked,
+        city_geoname_id: info.geo.city,
         country_geoname_id: info.geo.country,
-        postal_code:        info.geo.postal,
-        latitude:           info.geo.latitude,
-        longitude:          info.geo.longitude
-      }
-    }
+        postal_code: info.geo.postal,
+        latitude: info.geo.latitude,
+        longitude: info.geo.longitude,
+      },
+    };
   }
 
   userId(rec) {
     if (rec.userId) {
-      return rec.userId
+      return rec.userId;
     } else {
-      const parts = [rec.remoteAgent, rec.remoteIp, rec.remoteReferrer].join('-')
-      return crypto.createHash('md5').update(parts).digest('hex')
+      const parts = [rec.remoteAgent, rec.remoteIp, rec.remoteReferrer].join('-');
+      return crypto.createHash('md5').update(parts).digest('hex');
     }
   }
 
   insertId(epoch, userId, key, canonical) {
-    const parts = [epoch, userId, key, canonical].join('-')
-    return crypto.createHash('md5').update(parts).digest('hex')
+    const parts = [epoch, userId, key, canonical].join('-');
+    return crypto.createHash('md5').update(parts).digest('hex');
   }
 
   destination(rec) {
-    const parts = (rec.destination || '').split('.')
+    const parts = (rec.destination || '').split('.');
     if (parts.length === 2 && parts[0] && parts[1]) {
-      return `${parts[0]}.${parts[1]}`
+      return `${parts[0]}.${parts[1]}`;
     } else if (parts.length === 1 && parts[0] && process.env.BQ_DATASET) {
-      return `${process.env.BQ_DATASET}.${parts[0]}`
+      return `${process.env.BQ_DATASET}.${parts[0]}`;
     } else {
-      logger.error(`No destination in record: ${JSON.stringify(rec)}`)
-      return null
+      logger.error(`No destination in record: ${JSON.stringify(rec)}`);
+      return null;
     }
   }
-
-}
+};

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -135,7 +135,7 @@ describe('handler', () => {
       inserted['dt_impressions'][2].insertId,
     );
 
-    let impressionJson = inserted['dt_impressions'][0].json;
+    let impressionJson = inserted['dt_impressions'].find(i => i.json.ad_id === 12).json;
     expect(impressionJson.timestamp).to.equal(1487703699);
     expect(impressionJson.request_uuid).to.equal('req-uuid');
     expect(impressionJson.feeder_podcast).to.equal(1234);
@@ -150,21 +150,21 @@ describe('handler', () => {
     expect(impressionJson.creative_id).to.equal(56);
     expect(impressionJson.flight_id).to.equal(78);
 
-    impressionJson = inserted['dt_impressions'][1].json;
+    impressionJson = inserted['dt_impressions'].find(i => i.json.ad_id === 98).json;
     expect(impressionJson.ad_id).to.equal(98);
     expect(impressionJson.segment).to.equal(0);
     expect(impressionJson.is_confirmed).to.equal(true);
     expect(impressionJson.is_duplicate).to.equal(true);
     expect(impressionJson.cause).to.equal('something');
 
-    impressionJson = inserted['dt_impressions'][2].json;
+    impressionJson = inserted['dt_impressions'].find(i => i.json.ad_id === 76).json;
     expect(impressionJson.ad_id).to.equal(76);
     expect(impressionJson.segment).to.equal(3);
     expect(impressionJson.is_confirmed).to.equal(true);
     expect(impressionJson.is_duplicate).to.equal(false);
     expect(impressionJson.cause).to.equal(null);
 
-    impressionJson = inserted['dt_impressions'][3].json;
+    impressionJson = inserted['dt_impressions'].find(i => i.json.ad_id === 104).json;
     expect(impressionJson.vast_advertiser).to.equal('vastadvertiser1');
     expect(impressionJson.vast_ad_id).to.equal('vastad1');
     expect(impressionJson.vast_creative_id).to.equal('vastcreative1');

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -97,7 +97,7 @@ describe('handler', () => {
     );
 
     expect(inserted['dt_downloads'].length).to.equal(1);
-    expect(inserted['dt_downloads'][0].insertId).to.match(/^\w+\/1487703699$/);
+    expect(inserted['dt_downloads'][0].insertId).to.equal('listener-episode-1/1487703699');
     let downloadJson = inserted['dt_downloads'][0].json;
     expect(downloadJson.timestamp).to.equal(1487703699);
     expect(downloadJson.request_uuid).to.equal('req-uuid');
@@ -105,9 +105,7 @@ describe('handler', () => {
     expect(downloadJson.feeder_episode).to.equal('1234-5678');
     expect(downloadJson.listener_id).to.equal('some-listener-id');
     expect(downloadJson.listener_episode).to.equal('listener-episode-1');
-    expect(downloadJson.listener_session.length).to.be.above(10);
     expect(downloadJson.is_confirmed).to.equal(false);
-    expect(downloadJson.is_bytes).to.equal(false);
     expect(downloadJson.digest).to.equal('the-digest');
     expect(downloadJson.ad_count).to.equal(2);
     expect(downloadJson.is_duplicate).to.equal(false);
@@ -122,9 +120,6 @@ describe('handler', () => {
     expect(downloadJson.agent_os_id).to.equal(43);
     expect(downloadJson.city_geoname_id).to.equal(5576882);
     expect(downloadJson.country_geoname_id).to.equal(6252001);
-    expect(downloadJson.postal_code).to.equal('80517');
-    expect(Math.abs(downloadJson.latitude - 40.3772)).to.be.below(1);
-    expect(Math.abs(downloadJson.longitude + 105.5217)).to.be.below(1);
 
     expect(inserted['dt_impressions'].length).to.equal(4);
     expect(inserted['dt_impressions'][0].insertId.length).to.be.above(10);
@@ -145,11 +140,9 @@ describe('handler', () => {
     expect(impressionJson.request_uuid).to.equal('req-uuid');
     expect(impressionJson.feeder_podcast).to.equal(1234);
     expect(impressionJson.feeder_episode).to.equal('1234-5678');
-    expect(impressionJson.listener_session).to.equal(downloadJson.listener_session);
     expect(impressionJson.digest).to.equal('the-digest');
     expect(impressionJson.segment).to.equal(0);
     expect(impressionJson.is_confirmed).to.equal(false);
-    expect(impressionJson.is_bytes).to.equal(false);
     expect(impressionJson.is_duplicate).to.equal(false);
     expect(impressionJson.cause).to.be.null;
     expect(impressionJson.ad_id).to.equal(12);
@@ -180,11 +173,8 @@ describe('handler', () => {
     expect(impressionJson.vast_price_model).to.equal('CPM');
 
     let previewJson = inserted['dt_downloads_preview'][0].json;
-    expect(previewJson.listener_session.length).to.be.above(10);
-    expect(previewJson.listener_session).not.to.equal(downloadJson.listener_session);
     expect(previewJson.feeder_podcast).to.equal(1234);
     expect(previewJson.feeder_episode).to.equal('1234-5678');
-    expect(previewJson.is_bytes).to.equal(true);
     expect(previewJson.is_duplicate).to.equal(false);
     expect(previewJson.cause).to.equal(null);
 
@@ -194,9 +184,6 @@ describe('handler', () => {
       city_geoname_id: null,
       country_geoname_id: null,
       key: 'key1',
-      latitude: null,
-      longitude: null,
-      postal_code: null,
       remote_agent: 'some-user-agent',
       remote_ip: '127.0.0.0',
       remote_referrer: 'https://www.prx.org/technology/',

--- a/test/inputs-dovetail-downloads-test.js
+++ b/test/inputs-dovetail-downloads-test.js
@@ -5,39 +5,38 @@ const bigquery = require('../lib/bigquery');
 const DovetailDownloads = require('../lib/inputs/dovetail-downloads');
 
 describe('dovetail-downloads', () => {
-
   let download = new DovetailDownloads();
 
   it('recognizes download records', () => {
     expect(download.check({})).to.be.false;
-    expect(download.check({type: 'impression'})).to.be.false;
-    expect(download.check({type: 'download'})).to.be.false;
-    expect(download.check({type: 'combined', download: null})).to.be.false;
-    expect(download.check({type: 'combined', download: {}})).to.be.true;
-    expect(download.check({type: 'postbytes'})).to.be.false;
-    expect(download.check({type: 'postbytes', download: {}})).to.be.true;
-    expect(download.check({type: 'postbytespreview'})).to.be.false;
-    expect(download.check({type: 'postbytespreview', download: {}})).to.be.true;
+    expect(download.check({ type: 'impression' })).to.be.false;
+    expect(download.check({ type: 'download' })).to.be.false;
+    expect(download.check({ type: 'combined', download: null })).to.be.false;
+    expect(download.check({ type: 'combined', download: {} })).to.be.true;
+    expect(download.check({ type: 'postbytes' })).to.be.false;
+    expect(download.check({ type: 'postbytes', download: {} })).to.be.true;
+    expect(download.check({ type: 'postbytespreview' })).to.be.false;
+    expect(download.check({ type: 'postbytespreview', download: {} })).to.be.true;
   });
 
   it('knows the table names of records', () => {
-    expect(download.tableName({type: 'combined'})).to.equal('dt_downloads');
-    expect(download.tableName({type: 'postbytes'})).to.equal('dt_downloads');
-    expect(download.tableName({type: 'postbytespreview'})).to.equal('dt_downloads_preview');
+    expect(download.tableName({ type: 'combined' })).to.equal('dt_downloads');
+    expect(download.tableName({ type: 'postbytes' })).to.equal('dt_downloads');
+    expect(download.tableName({ type: 'postbytespreview' })).to.equal('dt_downloads_preview');
   });
 
   it('knows which records are bytes', () => {
-    expect(download.isBytes({type: 'combined'})).to.be.false;
-    expect(download.isBytes({type: 'postbytes'})).to.be.true;
-    expect(download.isBytes({type: 'postbytespreview'})).to.be.true;
+    expect(download.isBytes({ type: 'combined' })).to.be.false;
+    expect(download.isBytes({ type: 'postbytes' })).to.be.true;
+    expect(download.isBytes({ type: 'postbytespreview' })).to.be.true;
   });
 
   it('formats table inserts', async () => {
     const record = await download.format({
       type: 'combined',
       timestamp: 1490827132999,
-      download: {isDuplicate: true, cause: 'whatever'},
-      listenerEpisode: 'something'
+      download: { isDuplicate: true, cause: 'whatever' },
+      listenerEpisode: 'something',
     });
     expect(record).to.have.keys('insertId', 'json');
     expect(record.insertId).to.match(/^\w+\/1490827132$/);
@@ -66,7 +65,7 @@ describe('dovetail-downloads', () => {
       'country_geoname_id',
       'postal_code',
       'latitude',
-      'longitude'
+      'longitude',
     );
     expect(record.json.timestamp).to.equal(1490827132);
     expect(record.json.listener_episode).to.equal('something');
@@ -87,13 +86,18 @@ describe('dovetail-downloads', () => {
       return Promise.resolve(rows.length);
     });
     let download2 = new DovetailDownloads([
-      {type: 'download', requestUuid: 'the-uuid0', timestamp: 1490827132999},
-      {type: 'combined', download: {}, listenerEpisode: 'list-ep-1', timestamp: 1490827132999},
-      {type: 'impression', requestUuid: 'the-uuid2', timestamp: 1490827132999},
-      {type: 'combined', download: {}, listenerEpisode: 'list-ep-3', timestamp: 1490827132999},
-      {type: 'combined', download: {}, listenerEpisode: 'list-ep-4', timestamp: 1490827132999},
-      {type: 'postbytespreview', download: {}, listenerEpisode: 'list-ep-5', timestamp: 1490827132999},
-      {type: 'postbytes', download: {}, listenerEpisode: 'list-ep-6', timestamp: 1490827132999}
+      { type: 'download', requestUuid: 'the-uuid0', timestamp: 1490827132999 },
+      { type: 'combined', download: {}, listenerEpisode: 'list-ep-1', timestamp: 1490827132999 },
+      { type: 'impression', requestUuid: 'the-uuid2', timestamp: 1490827132999 },
+      { type: 'combined', download: {}, listenerEpisode: 'list-ep-3', timestamp: 1490827132999 },
+      { type: 'combined', download: {}, listenerEpisode: 'list-ep-4', timestamp: 1490827132999 },
+      {
+        type: 'postbytespreview',
+        download: {},
+        listenerEpisode: 'list-ep-5',
+        timestamp: 1490827132999,
+      },
+      { type: 'postbytes', download: {}, listenerEpisode: 'list-ep-6', timestamp: 1490827132999 },
     ]);
     return download2.insert().then(result => {
       expect(result.length).to.equal(2);
@@ -117,5 +121,4 @@ describe('dovetail-downloads', () => {
       expect(inserts['dt_downloads_preview'][0].json.is_bytes).to.equal(true);
     });
   });
-
 });

--- a/test/inputs-dovetail-downloads-test.js
+++ b/test/inputs-dovetail-downloads-test.js
@@ -25,12 +25,6 @@ describe('dovetail-downloads', () => {
     expect(download.tableName({ type: 'postbytespreview' })).to.equal('dt_downloads_preview');
   });
 
-  it('knows which records are bytes', () => {
-    expect(download.isBytes({ type: 'combined' })).to.be.false;
-    expect(download.isBytes({ type: 'postbytes' })).to.be.true;
-    expect(download.isBytes({ type: 'postbytespreview' })).to.be.true;
-  });
-
   it('formats table inserts', async () => {
     const record = await download.format({
       type: 'combined',
@@ -50,11 +44,9 @@ describe('dovetail-downloads', () => {
       'is_duplicate',
       'cause',
       'is_confirmed',
-      'is_bytes',
       'url',
       'listener_id',
       'listener_episode',
-      'listener_session',
       'remote_referrer',
       'remote_agent',
       'remote_ip',
@@ -63,9 +55,6 @@ describe('dovetail-downloads', () => {
       'agent_os_id',
       'city_geoname_id',
       'country_geoname_id',
-      'postal_code',
-      'latitude',
-      'longitude',
     );
     expect(record.json.timestamp).to.equal(1490827132);
     expect(record.json.listener_episode).to.equal('something');
@@ -106,19 +95,14 @@ describe('dovetail-downloads', () => {
       expect(result[0].count).to.equal(4);
       expect(inserts['dt_downloads'].length).to.equal(4);
       expect(inserts['dt_downloads'][0].json.listener_episode).to.equal('list-ep-1');
-      expect(inserts['dt_downloads'][0].json.is_bytes).to.equal(false);
       expect(inserts['dt_downloads'][1].json.listener_episode).to.equal('list-ep-3');
-      expect(inserts['dt_downloads'][1].json.is_bytes).to.equal(false);
       expect(inserts['dt_downloads'][2].json.listener_episode).to.equal('list-ep-4');
-      expect(inserts['dt_downloads'][2].json.is_bytes).to.equal(false);
       expect(inserts['dt_downloads'][3].json.listener_episode).to.equal('list-ep-6');
-      expect(inserts['dt_downloads'][3].json.is_bytes).to.equal(true);
 
       expect(result[1].dest).to.equal('dt_downloads_preview');
       expect(result[1].count).to.equal(1);
       expect(inserts['dt_downloads_preview'].length).to.equal(1);
       expect(inserts['dt_downloads_preview'][0].json.listener_episode).to.equal('list-ep-5');
-      expect(inserts['dt_downloads_preview'][0].json.is_bytes).to.equal(true);
     });
   });
 });

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -5,52 +5,63 @@ const bigquery = require('../lib/bigquery');
 const DovetailImpressions = require('../lib/inputs/dovetail-impressions');
 
 describe('dovetail-impressions', () => {
-
   let impression = new DovetailImpressions();
 
   it('recognizes impression records', () => {
-    expect(impression.check({type: null})).to.be.false;
-    expect(impression.check({type: undefined})).to.be.false;
-    expect(impression.check({type: 'download'})).to.be.false;
-    expect(impression.check({type: 'impression'})).to.be.false;
-    expect(impression.check({type: 'combined', impressions: []})).to.be.false;
-    expect(impression.check({type: 'postbytes', impressions: []})).to.be.false;
-    expect(impression.check({type: 'postbytes', impressions: [{}]})).to.be.true;
-    expect(impression.check({type: 'postbytespreview', impressions: []})).to.be.false;
-    expect(impression.check({type: 'postbytespreview', impressions: [{}]})).to.be.true;
+    expect(impression.check({ type: null })).to.be.false;
+    expect(impression.check({ type: undefined })).to.be.false;
+    expect(impression.check({ type: 'download' })).to.be.false;
+    expect(impression.check({ type: 'impression' })).to.be.false;
+    expect(impression.check({ type: 'combined', impressions: [] })).to.be.false;
+    expect(impression.check({ type: 'postbytes', impressions: [] })).to.be.false;
+    expect(impression.check({ type: 'postbytes', impressions: [{}] })).to.be.true;
+    expect(impression.check({ type: 'postbytespreview', impressions: [] })).to.be.false;
+    expect(impression.check({ type: 'postbytespreview', impressions: [{}] })).to.be.true;
   });
 
   it('knows the table names of records', () => {
-    expect(impression.tableName({type: 'combined'})).to.equal('dt_impressions');
-    expect(impression.tableName({type: 'postbytes'})).to.equal('dt_impressions');
-    expect(impression.tableName({type: 'postbytespreview'})).to.equal('dt_impressions_preview');
+    expect(impression.tableName({ type: 'combined' })).to.equal('dt_impressions');
+    expect(impression.tableName({ type: 'postbytes' })).to.equal('dt_impressions');
+    expect(impression.tableName({ type: 'postbytespreview' })).to.equal('dt_impressions_preview');
   });
 
   it('knows which records are bytes', () => {
-    expect(impression.isBytes({type: 'combined'})).to.be.false;
-    expect(impression.isBytes({type: 'postbytes'})).to.be.true;
-    expect(impression.isBytes({type: 'postbytespreview'})).to.be.true;
+    expect(impression.isBytes({ type: 'combined' })).to.be.false;
+    expect(impression.isBytes({ type: 'postbytes' })).to.be.true;
+    expect(impression.isBytes({ type: 'postbytespreview' })).to.be.true;
   });
 
   it('formats table inserts', async () => {
-    const rec = {type: 'combined', timestamp: 1490827132999, listenerEpisode: 'something'};
+    const rec = { type: 'combined', timestamp: 1490827132999, listenerEpisode: 'something' };
 
-    const format1 = await impression.format(rec, {adId: 1, isDuplicate: true});
+    const format1 = await impression.format(rec, { adId: 1, isDuplicate: true });
     expect(format1).to.have.keys('insertId', 'json');
     expect(format1.insertId.length).to.be.above(10);
     expect(format1.json).to.have.keys(
-      'timestamp', 'request_uuid', 'feeder_podcast', 'feeder_episode',
-      'digest', 'listener_session',
-      'is_confirmed', 'is_bytes', 'segment',
-      'ad_id', 'campaign_id', 'creative_id', 'flight_id',
-      'is_duplicate', 'cause',
-      'placements_key', 'target_path', 'zone_name',
+      'timestamp',
+      'request_uuid',
+      'feeder_podcast',
+      'feeder_episode',
+      'digest',
+      'listener_session',
+      'is_confirmed',
+      'is_bytes',
+      'segment',
+      'ad_id',
+      'campaign_id',
+      'creative_id',
+      'flight_id',
+      'is_duplicate',
+      'cause',
+      'placements_key',
+      'target_path',
+      'zone_name',
     );
     expect(format1.json.timestamp).to.equal(1490827132);
     expect(format1.json.listener_session.length).to.be.above(10);
     expect(format1.json.is_duplicate).to.equal(true);
 
-    const format2 = await impression.format(rec, {adId: 2, isDuplicate: false});
+    const format2 = await impression.format(rec, { adId: 2, isDuplicate: false });
     expect(format2.json.timestamp).to.equal(1490827132);
     expect(format2.json.listener_session).to.equal(format1.json.listener_session);
     expect(format2.json.is_duplicate).to.equal(false);
@@ -58,10 +69,10 @@ describe('dovetail-impressions', () => {
   });
 
   it('creates unique insert ids for ads', async () => {
-    const r1 = await impression.format({listenerEpisode: 'req1'}, {adId: 1});
-    const r2 = await impression.format({listenerEpisode: 'req1'}, {adId: 1});
-    const r3 = await impression.format({listenerEpisode: 'req1'}, {adId: 2});
-    const r4 = await impression.format({listenerEpisode: 'req2'}, {adId: 1});
+    const r1 = await impression.format({ listenerEpisode: 'req1' }, { adId: 1 });
+    const r2 = await impression.format({ listenerEpisode: 'req1' }, { adId: 1 });
+    const r3 = await impression.format({ listenerEpisode: 'req1' }, { adId: 2 });
+    const r4 = await impression.format({ listenerEpisode: 'req2' }, { adId: 1 });
     expect(r1.insertId).to.equal(r2.insertId);
     expect(r1.insertId).not.to.equal(r3.insertId);
     expect(r1.insertId).not.to.equal(r4.insertId);
@@ -80,15 +91,57 @@ describe('dovetail-impressions', () => {
       return Promise.resolve(rows.length);
     });
     let impression2 = new DovetailImpressions([
-      {type: 'impression', requestUuid: 'the-uuid1', timestamp: 1490827132999},
-      {type: 'download', requestUuid: 'the-uuid2', timestamp: 1490827132999},
-      {type: 'combined', listenerEpisode: 'listen1', timestamp: 1490837132, impressions: []},
-      {type: 'combined', listenerEpisode: 'listen2', timestamp: 1490827132999, impressions: [{adId: 1}, {adId: 2}]},
-      {type: 'combined', listenerEpisode: 'listen3', timestamp: 1490837132, impressions: [{isDuplicate: true, adId: 3}]},
-      {type: 'postbytespreview', listenerEpisode: 'listen4', timestamp: 1490837132, impressions: [{adId: 4}]},
-      {type: 'postbytes', listenerEpisode: 'listen5', timestamp: 1490827132999, impressions: [{adId: 5}]},
-      {type: 'combined', listenerEpisode: 'listen6', timestamp: 1490837132, impressions: [{targetPath: ':Some-target', zoneName: 'some_pre1', placementsKey: '2' }]},
-      {type: 'combined', listenerEpisode: 'listen7', timestamp: 1490827132999, impressions: [{vast: {advertiser: 'vastadvertiser1', ad: {id: 'vastadid1'}, creative: {id: 'vastcreativeid1'}, pricing: {value: '100.00', currency: 'USD', model: 'CPM'}}, targetPath: ':Some-target', zoneName: 'some_pre1', placementsKey: '2' }]},
+      { type: 'impression', requestUuid: 'the-uuid1', timestamp: 1490827132999 },
+      { type: 'download', requestUuid: 'the-uuid2', timestamp: 1490827132999 },
+      { type: 'combined', listenerEpisode: 'listen1', timestamp: 1490837132, impressions: [] },
+      {
+        type: 'combined',
+        listenerEpisode: 'listen2',
+        timestamp: 1490827132999,
+        impressions: [{ adId: 1 }, { adId: 2 }],
+      },
+      {
+        type: 'combined',
+        listenerEpisode: 'listen3',
+        timestamp: 1490837132,
+        impressions: [{ isDuplicate: true, adId: 3 }],
+      },
+      {
+        type: 'postbytespreview',
+        listenerEpisode: 'listen4',
+        timestamp: 1490837132,
+        impressions: [{ adId: 4 }],
+      },
+      {
+        type: 'postbytes',
+        listenerEpisode: 'listen5',
+        timestamp: 1490827132999,
+        impressions: [{ adId: 5 }],
+      },
+      {
+        type: 'combined',
+        listenerEpisode: 'listen6',
+        timestamp: 1490837132,
+        impressions: [{ targetPath: ':Some-target', zoneName: 'some_pre1', placementsKey: '2' }],
+      },
+      {
+        type: 'combined',
+        listenerEpisode: 'listen7',
+        timestamp: 1490827132999,
+        impressions: [
+          {
+            vast: {
+              advertiser: 'vastadvertiser1',
+              ad: { id: 'vastadid1' },
+              creative: { id: 'vastcreativeid1' },
+              pricing: { value: '100.00', currency: 'USD', model: 'CPM' },
+            },
+            targetPath: ':Some-target',
+            zoneName: 'some_pre1',
+            placementsKey: '2',
+          },
+        ],
+      },
     ]);
     return impression2.insert().then(result => {
       expect(result.length).to.equal(2);
@@ -114,7 +167,7 @@ describe('dovetail-impressions', () => {
       expect(inserts['dt_impressions'][5].json.vast_advertiser).to.equal('vastadvertiser1');
       expect(inserts['dt_impressions'][5].json.vast_ad_id).to.equal('vastadid1');
       expect(inserts['dt_impressions'][5].json.vast_creative_id).to.equal('vastcreativeid1');
-      expect(inserts['dt_impressions'][5].json.vast_price_value).to.equal(100.00);
+      expect(inserts['dt_impressions'][5].json.vast_price_value).to.equal(100.0);
       expect(inserts['dt_impressions'][5].json.vast_price_currency).to.equal('USD');
       expect(inserts['dt_impressions'][5].json.vast_price_model).to.equal('CPM');
 
@@ -125,5 +178,4 @@ describe('dovetail-impressions', () => {
       expect(inserts['dt_impressions_preview'][0].json.is_bytes).to.equal(true);
     });
   });
-
 });

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -25,12 +25,6 @@ describe('dovetail-impressions', () => {
     expect(impression.tableName({ type: 'postbytespreview' })).to.equal('dt_impressions_preview');
   });
 
-  it('knows which records are bytes', () => {
-    expect(impression.isBytes({ type: 'combined' })).to.be.false;
-    expect(impression.isBytes({ type: 'postbytes' })).to.be.true;
-    expect(impression.isBytes({ type: 'postbytespreview' })).to.be.true;
-  });
-
   it('formats table inserts', async () => {
     const rec = { type: 'combined', timestamp: 1490827132999, listenerEpisode: 'something' };
 
@@ -43,9 +37,7 @@ describe('dovetail-impressions', () => {
       'feeder_podcast',
       'feeder_episode',
       'digest',
-      'listener_session',
       'is_confirmed',
-      'is_bytes',
       'segment',
       'ad_id',
       'campaign_id',
@@ -58,12 +50,10 @@ describe('dovetail-impressions', () => {
       'zone_name',
     );
     expect(format1.json.timestamp).to.equal(1490827132);
-    expect(format1.json.listener_session.length).to.be.above(10);
     expect(format1.json.is_duplicate).to.equal(true);
 
     const format2 = await impression.format(rec, { adId: 2, isDuplicate: false });
     expect(format2.json.timestamp).to.equal(1490827132);
-    expect(format2.json.listener_session).to.equal(format1.json.listener_session);
     expect(format2.json.is_duplicate).to.equal(false);
     expect(format2.insertId).not.to.equal(format1.insertId);
   });
@@ -148,18 +138,10 @@ describe('dovetail-impressions', () => {
 
       expect(result[0].dest).to.equal('dt_impressions');
       expect(result[0].count).to.equal(6);
-      expect(inserts['dt_impressions'][0].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][0].json.ad_id).to.equal(1);
-      expect(inserts['dt_impressions'][0].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][1].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][1].json.ad_id).to.equal(2);
-      expect(inserts['dt_impressions'][1].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][2].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][2].json.ad_id).to.equal(3);
-      expect(inserts['dt_impressions'][2].json.is_bytes).to.equal(false);
-      expect(inserts['dt_impressions'][3].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions'][3].json.ad_id).to.equal(5);
-      expect(inserts['dt_impressions'][3].json.is_bytes).to.equal(true);
       expect(inserts['dt_impressions'][4].json.target_path).to.equal(':Some-target');
       expect(inserts['dt_impressions'][4].json.zone_name).to.equal('some_pre1');
       expect(inserts['dt_impressions'][4].json.placements_key).to.equal('2');
@@ -173,9 +155,7 @@ describe('dovetail-impressions', () => {
 
       expect(result[1].dest).to.equal('dt_impressions_preview');
       expect(result[1].count).to.equal(1);
-      expect(inserts['dt_impressions_preview'][0].json.listener_session.length).to.be.above(10);
       expect(inserts['dt_impressions_preview'][0].json.ad_id).to.equal(4);
-      expect(inserts['dt_impressions_preview'][0].json.is_bytes).to.equal(true);
     });
   });
 });

--- a/test/inputs-pixel-trackers-test.js
+++ b/test/inputs-pixel-trackers-test.js
@@ -53,9 +53,6 @@ describe('pixel-trackers', () => {
       remote_ip: '127.0.0.0',
       city_geoname_id: null,
       country_geoname_id: null,
-      postal_code: null,
-      latitude: null,
-      longitude: null,
     });
   });
 

--- a/test/inputs-pixel-trackers-test.js
+++ b/test/inputs-pixel-trackers-test.js
@@ -1,11 +1,10 @@
-const support = require('./support')
-const bigquery = require('../lib/bigquery')
-const logger = require('../lib/logger')
-const PixelTrackers = require('../lib/inputs/pixel-trackers')
+const support = require('./support');
+const bigquery = require('../lib/bigquery');
+const logger = require('../lib/logger');
+const PixelTrackers = require('../lib/inputs/pixel-trackers');
 
 describe('pixel-trackers', () => {
-
-  let pixel = new PixelTrackers()
+  let pixel = new PixelTrackers();
   const data = {
     type: 'pixel',
     timestamp: 1490827132999,
@@ -15,35 +14,35 @@ describe('pixel-trackers', () => {
     remoteIp: '127.0.0.1',
     remoteReferrer: 'the-referer',
     userId: 'the-user-id',
-  }
+  };
 
   it('recognizes pixel records', () => {
-    expect(pixel.check({})).to.be.false
-    expect(pixel.check({type: 'impression'})).to.be.false
-    expect(pixel.check({type: 'pixel'})).to.be.true
-  })
+    expect(pixel.check({})).to.be.false;
+    expect(pixel.check({ type: 'impression' })).to.be.false;
+    expect(pixel.check({ type: 'pixel' })).to.be.true;
+  });
 
   it('knows the destinations of records', () => {
-    expect(pixel.destination({destination: 'tablename'})).to.equal('foobar_dataset.tablename')
-    expect(pixel.destination({destination: 'foo.bar'})).to.equal('foo.bar')
-  })
+    expect(pixel.destination({ destination: 'tablename' })).to.equal('foobar_dataset.tablename');
+    expect(pixel.destination({ destination: 'foo.bar' })).to.equal('foo.bar');
+  });
 
   it('logs bad destinations', () => {
-    sinon.stub(logger, 'error')
+    sinon.stub(logger, 'error');
 
-    expect(pixel.destination({destination: ''})).to.be.null
-    expect(logger.error).to.have.callCount(1)
-    expect(logger.error.args[0][0]).to.match(/No destination in record:/)
+    expect(pixel.destination({ destination: '' })).to.be.null;
+    expect(logger.error).to.have.callCount(1);
+    expect(logger.error.args[0][0]).to.match(/No destination in record:/);
 
-    expect(pixel.destination({destination: 'one.two.three'})).to.be.null
-    expect(logger.error).to.have.callCount(2)
-    expect(logger.error.args[1][0]).to.match(/No destination in record:/)
-  })
+    expect(pixel.destination({ destination: 'one.two.three' })).to.be.null;
+    expect(logger.error).to.have.callCount(2);
+    expect(logger.error.args[1][0]).to.match(/No destination in record:/);
+  });
 
   it('formats table inserts', async () => {
-    const record = await pixel.format(data)
-    expect(record).to.have.keys('insertId', 'json')
-    expect(record.insertId.length).to.be.above(10)
+    const record = await pixel.format(data);
+    expect(record).to.have.keys('insertId', 'json');
+    expect(record.insertId.length).to.be.above(10);
     expect(record.json).to.eql({
       timestamp: 1490827132,
       user_id: 'the-user-id',
@@ -57,101 +56,106 @@ describe('pixel-trackers', () => {
       postal_code: null,
       latitude: null,
       longitude: null,
-    })
-  })
+    });
+  });
 
   it('generates unique user ids when not set', async () => {
-    const record1 = await pixel.format({...data, userId: undefined})
-    const record2 = await pixel.format({...data, userId: undefined, key: 'other-key'})
-    const record3 = await pixel.format({...data, userId: undefined, canonical: 'other-canonical'})
-    const record4 = await pixel.format({...data, userId: undefined, remoteIp: '127.0.0.2'})
-    expect(record1.json.user_id).to.equal(record2.json.user_id)
-    expect(record1.json.user_id).to.equal(record3.json.user_id)
-    expect(record1.json.user_id).not.to.equal(record4.json.user_id)
-  })
+    const record1 = await pixel.format({ ...data, userId: undefined });
+    const record2 = await pixel.format({ ...data, userId: undefined, key: 'other-key' });
+    const record3 = await pixel.format({
+      ...data,
+      userId: undefined,
+      canonical: 'other-canonical',
+    });
+    const record4 = await pixel.format({ ...data, userId: undefined, remoteIp: '127.0.0.2' });
+    expect(record1.json.user_id).to.equal(record2.json.user_id);
+    expect(record1.json.user_id).to.equal(record3.json.user_id);
+    expect(record1.json.user_id).not.to.equal(record4.json.user_id);
+  });
 
   it('generates unique insert ids', async () => {
-    const record1 = await pixel.format(data)
-    const record2 = await pixel.format({...data})
-    const record3 = await pixel.format({...data, key: 'other-key'})
-    const record4 = await pixel.format({...data, canonical: 'other-canonical'})
-    const record5 = await pixel.format({...data, timestamp: 123456789})
-    expect(record1.insertId).to.equal(record2.insertId)
-    expect(record1.insertId).not.to.equal(record3.insertId)
-    expect(record1.insertId).not.to.equal(record4.insertId)
-    expect(record1.insertId).not.to.equal(record5.insertId)
-  })
+    const record1 = await pixel.format(data);
+    const record2 = await pixel.format({ ...data });
+    const record3 = await pixel.format({ ...data, key: 'other-key' });
+    const record4 = await pixel.format({ ...data, canonical: 'other-canonical' });
+    const record5 = await pixel.format({ ...data, timestamp: 123456789 });
+    expect(record1.insertId).to.equal(record2.insertId);
+    expect(record1.insertId).not.to.equal(record3.insertId);
+    expect(record1.insertId).not.to.equal(record4.insertId);
+    expect(record1.insertId).not.to.equal(record5.insertId);
+  });
 
   it('inserts nothing', async () => {
-    const result = await pixel.insert()
-    expect(result.length).to.equal(0)
-  })
+    const result = await pixel.insert();
+    expect(result.length).to.equal(0);
+  });
 
   it('inserts download records', async () => {
-    let inserts = {}
+    let inserts = {};
     sinon.stub(bigquery, 'insert').callsFake(async (ds, tbl, rows) => {
-      inserts[`${ds}.${tbl}`] = rows
-      return rows.length
-    })
+      inserts[`${ds}.${tbl}`] = rows;
+      return rows.length;
+    });
 
     const pixel2 = new PixelTrackers([
-      {type: 'download', key: '1'},
-      {type: 'pixel', key: '2', destination: 'foo.bar'},
-      {type: 'pixel', key: '3', destination: 'bar'},
-      {type: 'pixel', key: '4', destination: 'foobar_dataset.bar'},
-      {type: 'pixel', key: '5', destination: 'bar'},
-      {type: 'pixel', key: '6', destination: 'foo.bar'},
-    ])
-    const results = await pixel2.insert()
-    expect(results.length).to.equal(2)
-    expect(results[0]).to.eql({count: 2, dest: 'foo.bar'})
-    expect(results[1]).to.eql({count: 3, dest: 'foobar_dataset.bar'})
-  })
+      { type: 'download', key: '1' },
+      { type: 'pixel', key: '2', destination: 'foo.bar' },
+      { type: 'pixel', key: '3', destination: 'bar' },
+      { type: 'pixel', key: '4', destination: 'foobar_dataset.bar' },
+      { type: 'pixel', key: '5', destination: 'bar' },
+      { type: 'pixel', key: '6', destination: 'foo.bar' },
+    ]);
+    const results = await pixel2.insert();
+    expect(results.length).to.equal(2);
+    expect(results[0]).to.eql({ count: 2, dest: 'foo.bar' });
+    expect(results[1]).to.eql({ count: 3, dest: 'foobar_dataset.bar' });
+  });
 
   it('catches table 404 errors', async () => {
-    sinon.stub(logger, 'error')
+    sinon.stub(logger, 'error');
     sinon.stub(bigquery, 'insert').callsFake(async () => {
-      const err = new Error('Table not found')
-      err.code = 404
-      throw err
-    })
+      const err = new Error('Table not found');
+      err.code = 404;
+      throw err;
+    });
 
-    const pixel2 = new PixelTrackers([{type: 'pixel', destination: 'foo.bar'}])
-    const results = await pixel2.insert()
-    expect(results.length).to.equal(1)
-    expect(results[0]).to.eql({count: 0, dest: 'foo.bar'})
+    const pixel2 = new PixelTrackers([{ type: 'pixel', destination: 'foo.bar' }]);
+    const results = await pixel2.insert();
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.eql({ count: 0, dest: 'foo.bar' });
 
-    expect(logger.error).to.have.callCount(1)
-    expect(logger.error.args[0][0]).to.match(/Table not found: foo.bar/)
-  })
+    expect(logger.error).to.have.callCount(1);
+    expect(logger.error.args[0][0]).to.match(/Table not found: foo.bar/);
+  });
 
   it('catches bigquery insert errors', async () => {
-    sinon.stub(logger, 'error')
+    sinon.stub(logger, 'error');
     sinon.stub(bigquery, 'insert').callsFake(async () => {
-      const err = new Error('A failure occurred during this request.')
-      err.name = 'PartialFailureError'
+      const err = new Error('A failure occurred during this request.');
+      err.name = 'PartialFailureError';
       err.response = {
         kind: 'bigquery#tableDataInsertAllResponse',
         insertErrors: [
-          {errors: [{location: 'timestamp', message: 'no such field.'}]},
-          {errors: [{location: 'other_thing', message: 'bad bad bad'}]},
-          {errors: [{location: 'timestamp', message: 'no such field.'}]},
-          {errors: [{message: 'just a message.'}]},
-          {errors: [{reason: 'just a reason.'}]},
+          { errors: [{ location: 'timestamp', message: 'no such field.' }] },
+          { errors: [{ location: 'other_thing', message: 'bad bad bad' }] },
+          { errors: [{ location: 'timestamp', message: 'no such field.' }] },
+          { errors: [{ message: 'just a message.' }] },
+          { errors: [{ reason: 'just a reason.' }] },
         ],
-      }
-      throw err
-    })
+      };
+      throw err;
+    });
 
-    const pixel2 = new PixelTrackers([{type: 'pixel', destination: 'foo.bar'}])
-    const results = await pixel2.insert()
-    expect(results.length).to.equal(1)
-    expect(results[0]).to.eql({count: 0, dest: 'foo.bar'})
+    const pixel2 = new PixelTrackers([{ type: 'pixel', destination: 'foo.bar' }]);
+    const results = await pixel2.insert();
+    expect(results.length).to.equal(1);
+    expect(results[0]).to.eql({ count: 0, dest: 'foo.bar' });
 
-    expect(logger.error).to.have.callCount(1)
-    const msg = logger.error.args[0][0]
-    expect(msg).to.match(/Insert errors on foo.bar:/)
-    expect(msg).to.match(/timestamp: no such field, other_thing: bad bad bad, just a message, just a reason/)
-  })
-
-})
+    expect(logger.error).to.have.callCount(1);
+    const msg = logger.error.args[0][0];
+    expect(msg).to.match(/Insert errors on foo.bar:/);
+    expect(msg).to.match(
+      /timestamp: no such field, other_thing: bad bad bad, just a message, just a reason/,
+    );
+  });
+});


### PR DESCRIPTION
Starting on "Phase 1: Cleanup Downloads" of [RFC 23](https://github.com/PRX/internal/pull/824).

Lot of linting (I added prettier to this project, and have been linting files as they change).  But [these 2 commits](https://github.com/PRX/analytics-ingest-lambda/pull/86/files/0af725eb8bbc5dc123b4a5be4072568eb616127a..edce8d07cc821c4eaf3183441915d95981241b4b) are the actual changes.  Notes:

- Didn't need to remove `program` `path` `clienthash` as they weren't even being inserted.
- Remove unused Maxmind fields `postal_code` `latitude` `longitude` from inserted `dt_downloads`.
- Remove `is_bytes` and `listener_session` from inserted `dt_downloads` and `dt_impressions`
- Also had to change the "insert IDs" to use the `listener_episode` instead of the session. BQ uses that to dedup inserts, but this should have no functional change since all the insert IDs also use the UTC day.