### PR TITLE
Keep both the city and country geonames around

### DIFF
--- a/lib/inputs/dovetail-downloads.js
+++ b/lib/inputs/dovetail-downloads.js
@@ -92,9 +92,8 @@ module.exports = class DovetailDownloads {
         agent_name_id: info.agent.name,
         agent_type_id: info.agent.type,
         agent_os_id: info.agent.os,
-        geoname_id: info.geo.city || info.geo.country,
-        city_geoname_id: info.geo.city, // TODO: remove
-        country_geoname_id: info.geo.country, // TODO: remove
+        city_geoname_id: info.geo.city,
+        country_geoname_id: info.geo.country,
       },
     };
   }

--- a/lib/inputs/dovetail-impressions.js
+++ b/lib/inputs/dovetail-impressions.js
@@ -88,7 +88,8 @@ module.exports = class DovetailImpressions {
         agent_name_id: info.agent.name,
         agent_type_id: info.agent.type,
         agent_os_id: info.agent.os,
-        geoname_id: info.geo.city || info.geo.country,
+        city_geoname_id: info.geo.city,
+        country_geoname_id: info.geo.country,
       },
     };
 

--- a/lib/inputs/pixel-trackers.js
+++ b/lib/inputs/pixel-trackers.js
@@ -72,9 +72,8 @@ module.exports = class PixelTrackers {
         remote_agent: record.remoteAgent,
         remote_referrer: record.remoteReferrer,
         remote_ip: info.geo.masked,
-        geoname_id: info.geo.city || info.geo.country,
-        city_geoname_id: info.geo.city, // TODO: remove
-        country_geoname_id: info.geo.country, // TODO: remove
+        city_geoname_id: info.geo.city,
+        country_geoname_id: info.geo.country,
       },
     };
   }

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -118,7 +118,6 @@ describe('handler', () => {
     expect(downloadJson.agent_name_id).to.equal(25);
     expect(downloadJson.agent_type_id).to.equal(36);
     expect(downloadJson.agent_os_id).to.equal(43);
-    expect(downloadJson.geoname_id).to.equal(5576882);
     expect(downloadJson.city_geoname_id).to.equal(5576882);
     expect(downloadJson.country_geoname_id).to.equal(6252001);
 
@@ -154,7 +153,8 @@ describe('handler', () => {
     expect(impressionJson.agent_name_id).to.equal(25);
     expect(impressionJson.agent_type_id).to.equal(36);
     expect(impressionJson.agent_os_id).to.equal(43);
-    expect(impressionJson.geoname_id).to.equal(5576882);
+    expect(impressionJson.city_geoname_id).to.equal(5576882);
+    expect(impressionJson.country_geoname_id).to.equal(6252001);
 
     impressionJson = inserted['dt_impressions'].find(i => i.json.ad_id === 98).json;
     expect(impressionJson.ad_id).to.equal(98);
@@ -187,7 +187,6 @@ describe('handler', () => {
     expect(inserted['pixels'].length).to.equal(1);
     expect(inserted['pixels'][0].json).to.eql({
       canonical: 'https://www.prx.org/url1',
-      geoname_id: null,
       city_geoname_id: null,
       country_geoname_id: null,
       key: 'key1',

--- a/test/inputs-dovetail-downloads-test.js
+++ b/test/inputs-dovetail-downloads-test.js
@@ -53,7 +53,6 @@ describe('dovetail-downloads', () => {
       'agent_name_id',
       'agent_type_id',
       'agent_os_id',
-      'geoname_id',
       'city_geoname_id',
       'country_geoname_id',
     );

--- a/test/inputs-dovetail-impressions-test.js
+++ b/test/inputs-dovetail-impressions-test.js
@@ -52,7 +52,8 @@ describe('dovetail-impressions', () => {
       'agent_name_id',
       'agent_type_id',
       'agent_os_id',
-      'geoname_id',
+      'city_geoname_id',
+      'country_geoname_id',
     );
     expect(format1.json.timestamp).to.equal(1490827132);
     expect(format1.json.is_duplicate).to.equal(true);

--- a/test/inputs-pixel-trackers-test.js
+++ b/test/inputs-pixel-trackers-test.js
@@ -51,7 +51,6 @@ describe('pixel-trackers', () => {
       remote_agent: 'the-user-agent',
       remote_referrer: 'the-referer',
       remote_ip: '127.0.0.0',
-      geoname_id: null,
       city_geoname_id: null,
       country_geoname_id: null,
     });


### PR DESCRIPTION
Turns out, some percentage of `geoname_id`s get deleted from subsequent version of the `GeoLite2-City-Locations-en.csv` file we use to generate our `geonames` table.  Something like 1.1% of city geoname ids, and maybe 0.005% of country geoname ids.

So keep them all, for now!

TODO: needs the new `dt_impressions` columns before merging.