### PR TITLE
Refactor ping requests

### DIFF
--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -57,7 +57,7 @@ exports.request = async (url, opts, data, timeout, timeoutWait) => {
         await sleep(timeoutWait);
       } else if (i < MAX_ATTEMPTS && err.code === 'EMFILE') {
         // TODO: does waiting/retrying these even help them succeed?
-        logger.warn(`EMFILE retry ${opts.url}`);
+        logger.warn(`EMFILE retry ${url}`);
         await sleep(100);
         await sleep(timeoutWait);
       } else {
@@ -92,7 +92,7 @@ function requestAsPromise(url, opts, data, timeoutMs) {
     const req = proto
       .request(url, opts, res => {
         if (res.statusCode >= 300) {
-          const err = new Error(`HTTP ${res.statusCode} from ${opts.url}`);
+          const err = new Error(`HTTP ${res.statusCode} from ${url}`);
           err.statusCode = res.statusCode;
           reject(err);
         } else {
@@ -103,7 +103,7 @@ function requestAsPromise(url, opts, data, timeoutMs) {
         // https://github.com/node-modules/agentkeepalive#support-reqreusedsocket
         // TODO: is this even helpful?
         if (req.reusedSocket && err.code === 'ECONNRESET') {
-          const err = new Error(`Reused socket for ${opts.url}`);
+          const err = new Error(`Reused socket for ${url}`);
           err.reusedSocket = true;
           reject(err);
         } else {
@@ -112,7 +112,7 @@ function requestAsPromise(url, opts, data, timeoutMs) {
       })
       .setTimeout(timeoutMs, () => {
         req.abort();
-        reject(new Error(`HTTP timeout from ${opts.url}`));
+        reject(new Error(`HTTP timeout from ${url}`));
       });
 
     // optional request body

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const url = require('url');
+const { parse } = require('url');
 const followRedirects = require('follow-redirects');
 followRedirects.maxRedirects = 10;
 const http = followRedirects.http;
@@ -12,51 +12,54 @@ const TIMEOUT_MS = 5000;
 const TIMEOUT_WAIT_MS = 1000;
 const MAX_ATTEMPTS = 3;
 
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+const getAgent = (url, a) => (a ? (url.match(/^https/) ? a.https : a.http) : undefined);
+
 /**
  * Attempt to GET a url, with retries/error handling
  */
-exports.ping = async (pingUrl, inputData, timeout, timeoutWait, agents) => {
-  let parsed = url.parse(pingUrl);
+exports.ping = async (url, inputData, timeout, timeoutWait, agents) => {
+  const opts = {
+    method: 'GET',
+    headers: exports.parseHeaders(inputData),
+    agent: getAgent(url, agents),
+  };
+  return exports.request(url, opts, null, timeout, timeoutWait);
+};
+
+/**
+ * Make a request with timeouts/retries
+ */
+exports.request = async (url, opts, data, timeout, timeoutWait) => {
+  timeout = timeout === undefined ? TIMEOUT_MS : timeout;
+  timeoutWait = timeoutWait === undefined ? TIMEOUT_WAIT_MS : timeoutWait;
+
+  // special cases
+  const parsed = parse(url);
   if (!parsed.host) {
-    throw new Error(`Invalid ping url: ${pingUrl}`);
+    throw new Error(`Invalid ping url: ${url}`);
   }
-  if (parsed.hostname === 'tps.doubleverify.com') {
+  if (parsed.host === 'tps.doubleverify.com') {
     throw new Error(`tps.doubleverify.com is not our friend`);
   }
-
-  // options
-  const opts = {
-    url: pingUrl,
-    host: parsed.hostname,
-    path: parsed.path,
-    port: parsed.port,
-    headers: exports.parseHeaders(inputData)
-  };
-  if (agents) {
-    opts.agents = agents;
-  }
-  timeout = (timeout === undefined) ? TIMEOUT_MS : timeout;
-  timeoutWait = (timeoutWait === undefined) ? TIMEOUT_WAIT_MS : timeoutWait;
-
-  // stop being sloooooooow
-  if (opts.host === 'sink.pdst.fm') {
+  if (parsed.host === 'sink.pdst.fm') {
     timeout = 1000;
   }
 
-  // get with retries
+  // retry 5XXs
   for (let i = 1; i <= MAX_ATTEMPTS; i++) {
     try {
-      await getAsPromise(opts, timeout);
+      await requestAsPromise(url, opts, data, timeout);
       return true;
     } catch (err) {
       if (i < MAX_ATTEMPTS && err.statusCode >= 500) {
-        logger.warn(`PINGRETRY ${err.statusCode} ${opts.url}`);
-        await new Promise(resolve => setTimeout(resolve, timeoutWait));
+        logger.warn(`PINGRETRY ${err.statusCode} ${url}`);
+        await sleep(timeoutWait);
       } else if (i < MAX_ATTEMPTS && err.code === 'EMFILE') {
         // TODO: does waiting/retrying these even help them succeed?
         logger.warn(`EMFILE retry ${opts.url}`);
-        await new Promise(r => setTimeout(r, 100));
-        await new Promise(resolve => setTimeout(resolve, timeoutWait));
+        await sleep(100);
+        await sleep(timeoutWait);
       } else {
         throw err;
       }
@@ -65,7 +68,7 @@ exports.ping = async (pingUrl, inputData, timeout, timeoutWait, agents) => {
 };
 
 // set headers to match original requester
-exports.parseHeaders = (data) => {
+exports.parseHeaders = data => {
   let headers = {};
   if (data && data.remoteAgent) {
     headers['User-Agent'] = data.remoteAgent;
@@ -83,30 +86,39 @@ exports.parseHeaders = (data) => {
 };
 
 // http.get as a promise
-function getAsPromise(opts, timeoutMs) {
+function requestAsPromise(url, opts, data, timeoutMs) {
   return new Promise((resolve, reject) => {
-    const getter = opts.url.match(/^https/) ? https : http;
-    const req = getter.get(opts, (res) => {
-      if (res.statusCode >= 300) {
-        const err = new Error(`HTTP ${res.statusCode} from ${opts.url}`);
-        err.statusCode = res.statusCode;
-        reject(err);
-      } else {
-        resolve(true);
-      }
-    }).on('error', err => {
-      // https://github.com/node-modules/agentkeepalive#support-reqreusedsocket
-      // TODO: is this even helpful?
-      if (req.reusedSocket && err.code === 'ECONNRESET') {
-        const err = new Error(`Reused socket for ${opts.url}`);
-        err.reusedSocket = true;
-        reject(err);
-      } else {
-        reject(err);
-      }
-    }).setTimeout(timeoutMs, () => {
-      req.abort();
-      reject(new Error(`HTTP timeout from ${opts.url}`));
-    });
+    const proto = url.match(/^https/) ? https : http;
+    const req = proto
+      .request(url, opts, res => {
+        if (res.statusCode >= 300) {
+          const err = new Error(`HTTP ${res.statusCode} from ${opts.url}`);
+          err.statusCode = res.statusCode;
+          reject(err);
+        } else {
+          resolve(true);
+        }
+      })
+      .on('error', err => {
+        // https://github.com/node-modules/agentkeepalive#support-reqreusedsocket
+        // TODO: is this even helpful?
+        if (req.reusedSocket && err.code === 'ECONNRESET') {
+          const err = new Error(`Reused socket for ${opts.url}`);
+          err.reusedSocket = true;
+          reject(err);
+        } else {
+          reject(err);
+        }
+      })
+      .setTimeout(timeoutMs, () => {
+        req.abort();
+        reject(new Error(`HTTP timeout from ${opts.url}`));
+      });
+
+    // optional request body
+    if (data) {
+      req.write(data);
+    }
+    req.end();
   });
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ioredis-mock": "^4.21.1",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "nock": "^10.0.6",
+    "nock": "^13.2.7",
     "prettier": "^2.3.1",
     "sinon": "^7.2.3",
     "sinon-chai": "^3.3.0",

--- a/test/handler-test.js
+++ b/test/handler-test.js
@@ -308,6 +308,7 @@ describe('handler', () => {
     const ping2 = nock('http://www.foo.bar').get('/ping2').reply(404);
     const ping3 = nock('http://www.foo.bar').get('/ping3').reply(200);
     const ping4 = nock('http://www.adzerk.bar').get('/ping4').reply(200);
+    const ping5 = nock('http://www.adzerk.bar').get('/ping5').reply(404);
 
     const result = await handler(event);
     expect(result).to.match(/inserted 2/i);
@@ -324,11 +325,14 @@ describe('handler', () => {
     expect(infos[3].meta).to.contain({ dest: 'www.adzerk.bar', rows: 1 });
     expect(warns[0]).to.match(/PINGFAIL error: http 404/i);
     expect(warns[0]).to.match(/ping2/);
+    expect(warns[1]).to.match(/PINGFAIL error: http 404/i);
+    expect(warns[1]).to.match(/ping5/);
 
     expect(ping1.isDone()).to.be.true;
     expect(ping2.isDone()).to.be.true;
     expect(ping3.isDone()).to.be.false;
     expect(ping4.isDone()).to.be.true;
+    expect(ping5.isDone()).to.be.true;
   });
 
   it('handles redis records', async () => {

--- a/test/support/test-records.json
+++ b/test/support/test-records.json
@@ -178,7 +178,7 @@
         "isDuplicate": false,
         "targetPath": ":",
         "cause": null,
-        "pings": ["http://www.adzerk.bar/ping4"],
+        "pings": ["http://www.adzerk.bar/ping5"],
         "vast": {
           "advertiser": "vastadvertiser1",
           "ad": { "id": "vastad1" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,29 +296,9 @@ buffer@4.9.2:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-call-bind@^1.0.0, call-bind@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
-  dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
-
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-chai@^4.1.2:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
-  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
-  dependencies:
-    assertion-error "^1.1.0"
-    check-error "^1.0.2"
-    deep-eql "^3.0.1"
-    get-func-name "^2.0.0"
-    pathval "^1.1.1"
-    type-detect "^4.0.5"
 
 chai@^4.2.0:
   version "4.2.0"
@@ -450,28 +430,9 @@ deep-eql@^3.0.1:
   dependencies:
     type-detect "^4.0.0"
 
-deep-equal@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
-  integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
-  dependencies:
-    is-arguments "^1.0.4"
-    is-date-object "^1.0.1"
-    is-regex "^1.0.4"
-    object-is "^1.0.1"
-    object-keys "^1.1.1"
-    regexp.prototype.flags "^1.2.0"
-
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
-
-define-properties@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
-  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
-  dependencies:
-    object-keys "^1.0.12"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -748,11 +709,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
 gaxios@^1.0.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-1.8.4.tgz#e08c34fe93c0a9b67a52b7b9e7a64e6435f9a339"
@@ -788,15 +744,6 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
-
-get-intrinsic@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
-  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
-  dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.1"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -903,18 +850,6 @@ has-flag@^1.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-
-has-symbols@^1.0.1, has-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
-  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
-
-has@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
-  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
-  dependencies:
-    function-bind "^1.1.1"
 
 he@1.1.1:
   version "1.1.1"
@@ -1027,35 +962,15 @@ ipaddr.js@^2.0.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.0.tgz#77ccccc8063ae71ab65c55f21b090698e763fc6e"
   integrity sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==
 
-is-arguments@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.1.0.tgz#62353031dfbee07ceb34656a6bde59efecae8dd9"
-  integrity sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==
-  dependencies:
-    call-bind "^1.0.0"
-
 is-buffer@^2.0.2:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
-is-date-object@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
-  integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
-
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
   integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
-
-is-regex@^1.0.4:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
-  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
-  dependencies:
-    call-bind "^1.0.2"
-    has-symbols "^1.0.2"
 
 is-stream-ended@^0.1.4:
   version "0.1.4"
@@ -1217,7 +1132,7 @@ lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.5:
+lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -1276,11 +1191,6 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -1290,13 +1200,6 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-mkdirp@^0.5.0:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
-  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  dependencies:
-    minimist "^1.2.5"
 
 mmdb-lib@1.2.0:
   version "1.2.0"
@@ -1372,20 +1275,15 @@ nise@^1.4.8:
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
 
-nock@^10.0.6:
-  version "10.0.6"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.6.tgz#e6d90ee7a68b8cfc2ab7f6127e7d99aa7d13d111"
-  integrity sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==
+nock@^13.2.7:
+  version "13.2.7"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.7.tgz#c93933b61df42f4f4b3a07fde946a4e209c0c168"
+  integrity sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==
   dependencies:
-    chai "^4.1.2"
     debug "^4.1.0"
-    deep-equal "^1.0.0"
     json-stringify-safe "^5.0.1"
-    lodash "^4.17.5"
-    mkdirp "^0.5.0"
-    propagate "^1.0.0"
-    qs "^6.5.1"
-    semver "^5.5.0"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
 
 node-fetch@^2.2.0, node-fetch@^2.3.0:
   version "2.6.1"
@@ -1418,24 +1316,6 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
-object-inspect@^1.9.0:
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
-  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
-
-object-is@^1.0.1:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.5.tgz#b9deeaa5fc7f1846a0faecdceec138e5778f53ac"
-  integrity sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-
-object-keys@^1.0.12, object-keys@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
-  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 once@1.x, once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1491,7 +1371,7 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
-pathval@^1.1.0, pathval@^1.1.1:
+pathval@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
@@ -1518,10 +1398,10 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-propagate@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
-  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 prx-ip-filter@^0.0.1:
   version "0.0.1"
@@ -1568,13 +1448,6 @@ punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-
-qs@^6.5.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
-  dependencies:
-    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -1631,14 +1504,6 @@ redis-parser@^3.0.0:
   integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
     redis-errors "^1.0.0"
-
-regexp.prototype.flags@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
 
 request@^2.87.0:
   version "2.88.0"
@@ -1715,15 +1580,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
-  dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
No functional changes - just refactoring a library in prep for #90 ...

Convert the `pingurl.js` library to eventually allow POST requests with a JSON body.  And still do the same magic for both GETs and POSTs, including:

- All the manual retry/wait-between-retries on 5XXs and other retryable things
- Http.Agent reuse/cleanup that lambdas seem to need
- Following redirects (though the POSTs won't really need that)
- Other socket-y magic for lambdas, that we've accumulated over time.