### PR TITLE
Truncate half of IPv6

### DIFF
--- a/lib/iputil.js
+++ b/lib/iputil.js
@@ -5,9 +5,9 @@ const ipaddr = require('ipaddr.js');
 /**
  * Sanity check ip addresses
  */
-exports.clean = (ipString) => {
+exports.clean = ipString => {
   return exports.cleanAll(ipString, false)[0];
-}
+};
 exports.cleanAll = (xffString, join = true) => {
   let parts = (xffString || '').split(',').map(s => s.trim());
   let cleaned = parts.filter(s => s && ipaddr.isValid(s));
@@ -16,12 +16,12 @@ exports.cleanAll = (xffString, join = true) => {
   } else {
     return cleaned;
   }
-}
+};
 
 /**
  * Bitmask ip to remove last octet(s)
  */
-exports.mask = (cleanIpString) => {
+exports.mask = cleanIpString => {
   if (ipaddr.isValid(cleanIpString)) {
     const bytes = ipaddr.parse(cleanIpString).toByteArray();
     if (bytes.length === 4) {
@@ -34,20 +34,20 @@ exports.mask = (cleanIpString) => {
   } else {
     return cleanIpString;
   }
-}
-exports.maskLeft = (cleanXffString) => {
+};
+exports.maskLeft = cleanXffString => {
   const parts = (cleanXffString || '').split(', ');
   parts[0] = exports.mask(parts[0]);
   return parts.join(', ');
-}
+};
 
 /**
  * Convert to a fixed length string
  */
-exports.fixed = (cleanIpString) => {
+exports.fixed = cleanIpString => {
   return exports.fixedKind(cleanIpString)[0];
-}
-exports.fixedKind = (cleanIpString) => {
+};
+exports.fixedKind = cleanIpString => {
   if (ipaddr.isValid(cleanIpString)) {
     const ip = ipaddr.parse(cleanIpString);
     if (ip.kind() === 'ipv4') {
@@ -58,4 +58,4 @@ exports.fixedKind = (cleanIpString) => {
   } else {
     return [cleanIpString, null];
   }
-}
+};

--- a/lib/iputil.js
+++ b/lib/iputil.js
@@ -19,7 +19,7 @@ exports.cleanAll = (xffString, join = true) => {
 };
 
 /**
- * Bitmask ip to remove last octet(s)
+ * Bitmask ip to remove last byte of v4, last half of v6
  */
 exports.mask = cleanIpString => {
   if (ipaddr.isValid(cleanIpString)) {
@@ -27,6 +27,12 @@ exports.mask = cleanIpString => {
     if (bytes.length === 4) {
       bytes[3] = 0;
     } else if (bytes.length === 16) {
+      bytes[8] = 0;
+      bytes[9] = 0;
+      bytes[10] = 0;
+      bytes[11] = 0;
+      bytes[12] = 0;
+      bytes[13] = 0;
       bytes[14] = 0;
       bytes[15] = 0;
     }

--- a/test/iputil-test.js
+++ b/test/iputil-test.js
@@ -21,7 +21,7 @@ describe('iputil', () => {
     expect(iputil.mask('blah')).to.equal('blah');
     expect(iputil.mask('1234.5678.1234.5678')).to.equal('1234.5678.1234.5678');
     expect(iputil.mask('192.168.0.1')).to.equal('192.168.0.0');
-    expect(iputil.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65:1:3:3561::');
+    expect(iputil.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65::');
   });
 
   it('masks the leftmost x-forwarded-for ip', () => {
@@ -29,6 +29,7 @@ describe('iputil', () => {
     expect(iputil.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal(
       'unknown, 99.99.99.99, 127.0.0.1',
     );
+    expect(iputil.maskLeft('1:2:3:4:5::, 127.0.0.1')).to.equal('1:2:3:4::, 127.0.0.1');
   });
 
   it('converts to fixed length strings', () => {

--- a/test/iputil-test.js
+++ b/test/iputil-test.js
@@ -4,7 +4,6 @@ const support = require('./support');
 const iputil = require('../lib/iputil');
 
 describe('iputil', () => {
-
   it('cleans ips', () => {
     expect(iputil.clean('')).to.equal(undefined);
     expect(iputil.clean(',blah')).to.equal(undefined);
@@ -27,21 +26,27 @@ describe('iputil', () => {
 
   it('masks the leftmost x-forwarded-for ip', () => {
     expect(iputil.maskLeft('66.6.44.4, 99.99.99.99')).to.equal('66.6.44.0, 99.99.99.99');
-    expect(iputil.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal('unknown, 99.99.99.99, 127.0.0.1');
+    expect(iputil.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal(
+      'unknown, 99.99.99.99, 127.0.0.1',
+    );
   });
 
   it('converts to fixed length strings', () => {
     expect(iputil.fixed('blah')).to.equal('blah');
     expect(iputil.fixed('1234.5678.1234.5678')).to.equal('1234.5678.1234.5678');
     expect(iputil.fixed('192.68.0.1')).to.equal('192.068.000.001');
-    expect(iputil.fixed('2804:18:1012::61:14b8')).to.equal('2804:0018:1012:0000:0000:0000:0061:14b8');
+    expect(iputil.fixed('2804:18:1012::61:14b8')).to.equal(
+      '2804:0018:1012:0000:0000:0000:0061:14b8',
+    );
   });
 
   it('converts to fixed length strings and returns the kind of ip', () => {
     expect(iputil.fixedKind('blah')).to.eql(['blah', null]);
     expect(iputil.fixedKind('1234.5678.1234.5678')).to.eql(['1234.5678.1234.5678', null]);
     expect(iputil.fixedKind('192.68.0.1')).to.eql(['192.068.000.001', 'v4']);
-    expect(iputil.fixedKind('2804:18:1012::61:14b8')).to.eql(['2804:0018:1012:0000:0000:0000:0061:14b8', 'v6']);
+    expect(iputil.fixedKind('2804:18:1012::61:14b8')).to.eql([
+      '2804:0018:1012:0000:0000:0000:0061:14b8',
+      'v6',
+    ]);
   });
-
 });

--- a/test/pingurl-test.js
+++ b/test/pingurl-test.js
@@ -145,7 +145,7 @@ describe('pingurl', () => {
   it('masks ips in x-forwarded-for', () => {
     expect(parseXff('')).to.equal(undefined);
     expect(parseXff('66.6.44.4')).to.equal('66.6.44.0');
-    expect(parseXff('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65:1:3:3561::');
+    expect(parseXff('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65::');
     expect(parseXff(',blah ,  66.6.44.4')).to.equal('66.6.44.0');
     expect(parseXff('192.168.0.1,66.6.44.4')).to.equal('192.168.0.0, 66.6.44.4');
   });


### PR DESCRIPTION
For #100.

Update the `mask` utility method to remove half of IPv6.  Matches what DovetailRouter does when calculating listener ids.

This causes:

- BigQuery `dt_downloads.remote_ip` will now be half truncated for IPv6 (currently just removing the last 16 bits).
- Pingbacks `{ipmask}` query param will now be half truncated for IPv6. Full `{ip}` unchanged.
- Pingbacks XFF header now half truncated for IPv6.  (We currently _always_ truncate the XFF, regardless if the url has the full `{ip}` param in it or not).