### PR TITLE
Add an ipv4 only macro

### DIFF
--- a/lib/iputil.js
+++ b/lib/iputil.js
@@ -41,11 +41,28 @@ exports.mask = cleanIpString => {
     return cleanIpString;
   }
 };
+
 exports.maskLeft = cleanXffString => {
   const parts = (cleanXffString || '').split(', ');
   parts[0] = exports.mask(parts[0]);
   return parts.join(', ');
 };
+
+/**
+ * Some vendors can only handle IPv4 addresses, so send only those
+ */
+exports.ipV4Only = cleanIpString => {
+  if (ipaddr.isValid(cleanIpString)) {
+    const ip = ipaddr.parse(cleanIpString);
+    if (ip.kind() === 'ipv4') {
+      return cleanIpString;
+    } else {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+}
 
 /**
  * Convert to a fixed length string

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -52,6 +52,7 @@ const TPL_PARAMS = {
   flight:          'flightId',
   ip:              'remoteIp',
   ipmask:          'remoteIp',
+  ipv4:            'remoteIp',
   listener:        'listenerId',
   listenerepisode: 'listenerEpisode',
   podcast:         'feederPodcast',
@@ -68,6 +69,7 @@ const TPL_PARAMS = {
 const TPL_TRANSFORMS = {
   agentmd5:  ua => crypto.createHash('md5').update(ua || '').digest('hex'),
   ip:        ip => iputil.clean(ip),
+  ipv4:      ip => iputil.ipV4Only(iputil.clean(ip)),
   ipmask:    ip => iputil.mask(iputil.clean(ip)),
   timestamp: ts => timestamp.toEpochMilliseconds(ts),
   randomint: (timestamp, params) => Math.floor(Math.random() * MAXINT),

--- a/test/iputil-test.js
+++ b/test/iputil-test.js
@@ -24,6 +24,13 @@ describe('iputil', () => {
     expect(iputil.mask('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('2804:18:1012:6b65::');
   });
 
+  it('only ipv4s', () => {
+    expect(iputil.ipV4Only('blah')).to.equal('');
+    expect(iputil.ipV4Only('1234.5678.1234.5678')).to.equal('');
+    expect(iputil.ipV4Only('192.168.0.1')).to.equal('192.168.0.1');
+    expect(iputil.ipV4Only('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('');
+  });
+
   it('masks the leftmost x-forwarded-for ip', () => {
     expect(iputil.maskLeft('66.6.44.4, 99.99.99.99')).to.equal('66.6.44.0, 99.99.99.99');
     expect(iputil.maskLeft('unknown, 99.99.99.99, 127.0.0.1')).to.equal(

--- a/test/iputil-test.js
+++ b/test/iputil-test.js
@@ -25,10 +25,10 @@ describe('iputil', () => {
   });
 
   it('only ipv4s', () => {
-    expect(iputil.ipV4Only('blah')).to.equal('');
-    expect(iputil.ipV4Only('1234.5678.1234.5678')).to.equal('');
+    expect(iputil.ipV4Only('blah')).to.equal(undefined);
+    expect(iputil.ipV4Only('1234.5678.1234.5678')).to.equal(undefined);
     expect(iputil.ipV4Only('192.168.0.1')).to.equal('192.168.0.1');
-    expect(iputil.ipV4Only('2804:18:1012:6b65:1:3:3561:14b8')).to.equal('');
+    expect(iputil.ipV4Only('2804:18:1012:6b65:1:3:3561:14b8')).to.equal(undefined);
   });
 
   it('masks the leftmost x-forwarded-for ip', () => {

--- a/test/urlutil-test.js
+++ b/test/urlutil-test.js
@@ -89,6 +89,17 @@ describe('urlutil', () => {
     expect(url3).to.equal('http://foo.bar/');
   });
 
+  it('only ipv4 addresses', () => {
+    let url1 = urlutil.expand('http://foo.bar/{?ipv4}', TEST_IMPRESSION());
+    let url2 = urlutil.expand('http://foo.bar/{?ipv4}', TEST_IMPRESSION('remoteIp', '  what , 127.0.0.1'));
+    let url3 = urlutil.expand('http://foo.bar/{?ipv4}', TEST_IMPRESSION('remoteIp', '  '));
+    let url4 = urlutil.expand('http://foo.bar/{?ipv4}', TEST_IMPRESSION('remoteIp', '  what , 2804:18:1012:6b65::'));
+    expect(url1).to.equal('http://foo.bar/?ipv4=127.0.0.1');
+    expect(url2).to.equal('http://foo.bar/?ipv4=127.0.0.1');
+    expect(url3).to.equal('http://foo.bar/');
+    expect(url4).to.equal('http://foo.bar/');
+  });
+
   it('returns timestamps in milliseconds', () => {
     let url1 = urlutil.expand('http://foo.bar/{?timestamp}', TEST_IMPRESSION());
     let url2 = urlutil.expand('http://foo.bar/{?timestamp}', TEST_IMPRESSION('timestamp', 1507234920010));


### PR DESCRIPTION
There's a data analysis vendor that can only handle ipv4 addresses for their processing.
They requested a macro for pingback requests that only returns ipv4 addresses, i.e. it will be blank/no value for ipv6 addresses.