### PR TITLE
Skip impressions in a record that do not have a frequency cap

### DIFF
--- a/lib/inputs/dovetail-frequency.js
+++ b/lib/inputs/dovetail-frequency.js
@@ -52,7 +52,7 @@ module.exports = class DovetailFrequency {
     let updates = [];
     await this.eachImpression(async (rec, imp) => {
       const { isDuplicate } = await assayer.testImpression(rec, imp);
-      if (!isDuplicate) {
+      if (!isDuplicate && this.checkFrequency(imp)) {
         logger.debug('Record that impression!', { rec: rec, imp: imp });
         const data = this.format(rec, imp);
         if (data.timestamp > this.minImpressionTime(data)) {

--- a/test/inputs-dovetail-frequency-test.js
+++ b/test/inputs-dovetail-frequency-test.js
@@ -125,7 +125,7 @@ describe('dovetail-frequency', () => {
         type: 'postbytes',
         listenerId: 'listener2',
         timestamp: `${current - 40}`,
-        impressions: [{ campaignId: 400, frequency: "1:1" }],
+        impressions: [{ campaignId: 400, frequency: "1:1" }, { campaignId: 404 }],
       },
     ]);
     return frequency.insert().then(result => {


### PR DESCRIPTION
When a `postbytes` record comes in for a download, it can contain multiple impressions.

In other analytics lambdas, the whole record is checked for whether to process or not, and if so, all the impressions are processed.

In the frequency lambda, some impressions may be frequency capped, others in the same record will not be.
So, we need to check for impressions with frequency caps both for including in the records to process, and then again check each impression before recording to dynamodb.