### PR TITLE
Log when router duplicate causes mismatch ours

### DIFF
--- a/lib/assayer.js
+++ b/lib/assayer.js
@@ -2,6 +2,7 @@
 
 const domainthreat = require('./assays/domainthreat');
 const datacenter = require('./assays/datacenter');
+const logger = require('./logger');
 
 /**
  * Determine if a download is a duplicate, and return metadata.
@@ -14,8 +15,18 @@ exports.test = async record => {
   if (record.download && record.download.isDuplicate) {
     return { isDuplicate: true, cause: record.download.cause || 'unknown' };
   } else if (threat) {
+    if (record.download?.cause !== 'domainthreat') {
+      const analytics = 'domainthreat';
+      const router = record.download?.cause || '';
+      logger.warn('MISMATCHED domainthreat', { analytics, router });
+    }
     return { isDuplicate: true, cause: 'domainthreat' };
   } else if (center.provider) {
+    if (record.download?.cause !== `datacenter: ${center.provider}`) {
+      const analytics = `datacenter: ${center.provider}`;
+      const router = record.download?.cause || '';
+      logger.warn(`MISMATCHED datacenter`, { analytics, router });
+    }
     return { isDuplicate: true, cause: `datacenter: ${center.provider}` };
   } else {
     return { isDuplicate: false, cause: null };

--- a/test/assayer-test.js
+++ b/test/assayer-test.js
@@ -34,13 +34,15 @@ describe('assayer', () => {
     });
 
     it('checks for domain threats', async () => {
-      const info = await assayer.test({ remoteReferrer: 'http://cav.is/any/thing' });
+      const download = { cause: 'domainthreat' };
+      const info = await assayer.test({ remoteReferrer: 'http://cav.is/any/thing', download });
       expect(info.isDuplicate).to.equal(true);
       expect(info.cause).to.equal('domainthreat');
     });
 
     it('checks for datacenters', async () => {
-      const info = await assayer.test({ remoteIp: KNOWN_DATACENTER_IP });
+      const download = { cause: 'datacenter: Amazon AWS' };
+      const info = await assayer.test({ remoteIp: KNOWN_DATACENTER_IP, download });
       expect(info.isDuplicate).to.equal(true);
       expect(info.cause).to.equal('datacenter: Amazon AWS');
     });


### PR DESCRIPTION
Moving datacenter/domain logic into Router.  But first, let's make sure they match.