### PR TITLE
Full IP in XFF headers

### DIFF
--- a/index-pingbacks.js
+++ b/index-pingbacks.js
@@ -18,7 +18,12 @@ export const handler = async (event) => {
     .filter((r) => r.type === "postbytes")
     .flatMap((r) => (r.impressions || []).map((i) => ({ ...r, ...i })))
     .filter((r) => !r.isDuplicate);
-  const pings = imps.flatMap((r) => (r.pings || []).map((pingUrl) => ({ ...r, pingUrl })));
+  const pings = imps.flatMap((rec) => {
+    return (rec.pings || []).map((pingUrl, idx) => {
+      const fullIp = rec.pingFullIps ? rec.pingFullIps[idx] : undefined;
+      return { ...rec, pingUrl, fullIp };
+    });
+  });
 
   const info = { records: records.length, pingbacks: pings.length, increments: imps.length };
   log.info("Starting Pingbacks", info);

--- a/lib/pingurl.js
+++ b/lib/pingurl.js
@@ -96,7 +96,11 @@ export const parseHeaders = (data) => {
   if (data?.remoteIp) {
     const clean = iputil.cleanAll(data.remoteIp);
     if (clean) {
-      headers["X-Forwarded-For"] = iputil.maskLeft(clean);
+      if (data.fullIp) {
+        headers["X-Forwarded-For"] = clean;
+      } else {
+        headers["X-Forwarded-For"] = iputil.maskLeft(clean);
+      }
     }
   }
   if (data?.remoteReferrer) {

--- a/lib/pingurl.test.js
+++ b/lib/pingurl.test.js
@@ -135,5 +135,17 @@ describe("pingurl", () => {
       expect(parseXff(",blah ,  66.6.44.4")).toEqual("66.6.44.0");
       expect(parseXff("192.168.0.1,66.6.44.4")).toEqual("192.168.0.0, 66.6.44.4");
     });
+
+    it("provides full ips in x-forwarded-for", () => {
+      const parseXff = (remoteIp) => {
+        return pingurl.parseHeaders({ remoteIp, fullIp: true })["X-Forwarded-For"];
+      };
+
+      expect(parseXff("")).toEqual(undefined);
+      expect(parseXff("66.6.44.4")).toEqual("66.6.44.4");
+      expect(parseXff("1:2:3:4:5:6:7:8")).toEqual("1:2:3:4:5:6:7:8");
+      expect(parseXff(",blah ,  66.6.44.4")).toEqual("66.6.44.4");
+      expect(parseXff("192.168.0.1,66.6.44.4")).toEqual("192.168.0.1, 66.6.44.4");
+    });
   });
 });

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -49,6 +49,17 @@ export const expand = (tpl, data = {}) => {
   }
 };
 
+/**
+ * Restrict full ip permissions
+ */
+export const cleanFullIp = (ip, data = {}) => {
+  if (data.fullIp || data.fullIp === undefined) {
+    return iputil.clean(ip);
+  } else {
+    return iputil.mask(iputil.clean(ip));
+  }
+};
+
 // param mapping for templates
 const TPL_PARAMS = {
   ad: "adId",
@@ -78,20 +89,8 @@ const TPL_TRANSFORMS = {
       .createHash("md5")
       .update(ua || "")
       .digest("hex"),
-  ip: (ip, data) => {
-    if (data.fullIp || data.fullIp === undefined) {
-      return iputil.clean(ip);
-    } else {
-      return iputil.mask(iputil.clean(ip));
-    }
-  },
-  ipv4: (ip, data) => {
-    if (data.fullIp || data.fullIp === undefined) {
-      return iputil.ipV4Only(iputil.clean(ip));
-    } else {
-      return iputil.ipV4Only(iputil.mask(iputil.clean(ip)));
-    }
-  },
+  ip: (ip, data) => cleanFullIp(ip, data),
+  ipv4: (ip, data) => iputil.ipV4Only(cleanFullIp(ip, data)),
   ipmask: (ip) => iputil.mask(iputil.clean(ip)),
   timestamp: (ts) => timestamp.toEpochMilliseconds(ts),
   randomint: () => Math.floor(Math.random() * MAXINT),

--- a/lib/urlutil.js
+++ b/lib/urlutil.js
@@ -34,7 +34,7 @@ export const expand = (tpl, data = {}) => {
   });
 
   Object.keys(TPL_TRANSFORMS).forEach((key) => {
-    params[key] = TPL_TRANSFORMS[key](params[key], params);
+    params[key] = TPL_TRANSFORMS[key](params[key], data);
   });
 
   const adPosition = new AdPosition(data);
@@ -78,14 +78,26 @@ const TPL_TRANSFORMS = {
       .createHash("md5")
       .update(ua || "")
       .digest("hex"),
-  ip: (ip) => iputil.clean(ip),
-  ipv4: (ip) => iputil.ipV4Only(iputil.clean(ip)),
+  ip: (ip, data) => {
+    if (data.fullIp || data.fullIp === undefined) {
+      return iputil.clean(ip);
+    } else {
+      return iputil.mask(iputil.clean(ip));
+    }
+  },
+  ipv4: (ip, data) => {
+    if (data.fullIp || data.fullIp === undefined) {
+      return iputil.ipV4Only(iputil.clean(ip));
+    } else {
+      return iputil.ipV4Only(iputil.mask(iputil.clean(ip)));
+    }
+  },
   ipmask: (ip) => iputil.mask(iputil.clean(ip)),
   timestamp: (ts) => timestamp.toEpochMilliseconds(ts),
-  randomint: (_timestamp, _params) => Math.floor(Math.random() * MAXINT),
-  randomstr: (timestamp, params) => {
+  randomint: () => Math.floor(Math.random() * MAXINT),
+  randomstr: (ts, data) => {
     const hmac = crypto.createHmac("sha256", "the-secret-key");
-    hmac.update(`${timestamp}-${params.listenerepisode}-${params.ad}`);
+    hmac.update(`${ts}-${data.listenerEpisode}-${data.adId}`);
     return hmac.digest("base64").replace(/\+|\/|=/g, (match) => {
       if (match === "+") {
         return "-";
@@ -96,7 +108,7 @@ const TPL_TRANSFORMS = {
       return "";
     });
   },
-  url: (url, _p) => {
+  url: (url) => {
     if (url && url[0] === "/") {
       return `dovetail.prxu.org${url}`;
     } else {

--- a/lib/urlutil.test.js
+++ b/lib/urlutil.test.js
@@ -100,6 +100,22 @@ describe("urlutil", () => {
       expect(url4).toEqual("http://foo/");
     });
 
+    it("downgrades full IP addresses", () => {
+      const remoteIp = "127.0.0.1";
+      const url1 = urlutil.expand("http://foo/{?ip}", testImp({ remoteIp, fullIp: true }));
+      const url2 = urlutil.expand("http://foo/{?ip}", testImp({ remoteIp, fullIp: false }));
+      const url3 = urlutil.expand("http://foo/{?ip}", testImp({ remoteIp, fullIp: null }));
+      const url4 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp, fullIp: true }));
+      const url5 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp, fullIp: false }));
+      const url6 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp, fullIp: null }));
+      expect(url1).toEqual("http://foo/?ip=127.0.0.1");
+      expect(url2).toEqual("http://foo/?ip=127.0.0.0");
+      expect(url3).toEqual("http://foo/?ip=127.0.0.0");
+      expect(url4).toEqual("http://foo/?ipv4=127.0.0.1");
+      expect(url5).toEqual("http://foo/?ipv4=127.0.0.0");
+      expect(url6).toEqual("http://foo/?ipv4=127.0.0.0");
+    });
+
     it("returns timestamps in milliseconds", () => {
       const url1 = urlutil.expand("http://foo/{?timestamp}", testImp());
       const url2 = urlutil.expand("http://foo/{?timestamp}", testImp({ timestamp: 1507234920010 }));

--- a/lib/urlutil.test.js
+++ b/lib/urlutil.test.js
@@ -93,7 +93,7 @@ describe("urlutil", () => {
       const url1 = urlutil.expand("http://foo/{?ipv4}", testImp());
       const url2 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp: "what , 127.0.0.1" }));
       const url3 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp: "  " }));
-      const url4 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp: "w, 2804:18:0:::" }));
+      const url4 = urlutil.expand("http://foo/{?ipv4}", testImp({ remoteIp: "a, 1:2:3:4::,ev" }));
       expect(url1).toEqual("http://foo/?ipv4=127.0.0.1");
       expect(url2).toEqual("http://foo/?ipv4=127.0.0.1");
       expect(url3).toEqual("http://foo/");


### PR DESCRIPTION
Since https://github.com/PRX/dovetail-router.prx.org/pull/390, we now have the full IP permission coming over with pingbacks:

```json
{
  "pingFullIps": [false, true, null],
  "pings": [
    "https://some.where/{?ip}",
    "https://else.where/{?ipv4}",
    "http://not.an.external.system/{?ip}"
  ]
}
```

Use these to (A) allow full IP address in the XFF header.  And (B) downgrade an disallowed full `{ip}` / `{ipv4}` param.