### PR TITLE
Log bigquery lag

### DIFF
--- a/index-bigquery.js
+++ b/index-bigquery.js
@@ -28,7 +28,10 @@ export const handler = async (event) => {
   const impRows = imps.map((r, i) => formatImpression(r, i));
   const impCount = await bigquery.insert({ client, table: "dt_impressions", rows: impRows });
 
-  const info2 = { records: records.length, downloads: downCount, impressions: impCount };
+  const times = downRows.concat(impRows).map((r) => new Date(r.json.timestamp).getTime());
+  const lag = times.length ? Date.now() - Math.min(...times) : undefined;
+
+  const info2 = { records: records.length, downloads: downCount, impressions: impCount, lag };
   log.info("Finished BigQuery", info2);
 };
 

--- a/index-bigquery.test.js
+++ b/index-bigquery.test.js
@@ -27,7 +27,14 @@ describe("index-bigquery", () => {
       expect(log.info.mock.calls[0][0]).toEqual("Starting BigQuery");
       expect(log.info.mock.calls[0][1]).toEqual({ records: 7, downloads: 1, impressions: 4 });
       expect(log.info.mock.calls[1][0]).toEqual("Finished BigQuery");
-      expect(log.info.mock.calls[1][1]).toEqual({ records: 7, downloads: 1, impressions: 4 });
+      expect(log.info.mock.calls[1][1].records).toEqual(7);
+      expect(log.info.mock.calls[1][1].downloads).toEqual(1);
+      expect(log.info.mock.calls[1][1].impressions).toEqual(4);
+
+      // test record timestamps are on 2017-02-21
+      const lagDate = new Date(Date.now() - log.info.mock.calls[1][1].lag);
+      expect(lagDate.getTime()).toBeGreaterThan(new Date("2017-02-21").getTime());
+      expect(lagDate.getTime()).toBeLessThan(new Date("2017-02-22").getTime());
 
       expect(inserts[0].length).toEqual(1);
       expect(inserts[0][0].insertId).toEqual("listener-episode-1/1487703699000");


### PR DESCRIPTION
Some of the bigquery metadata tables indicate we're "modifying" day partitions hours into the next UTC day.  We've always sort of assumed it would only be minutes.

Let's keep an eye on how far behind we are... this PR logs the `lag` milliseconds of `Date.now()` vs the earliest record we're inserting.